### PR TITLE
Add support for summaries and histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ it. For development, we recommend using [Docker](https://docs.docker.com/install
 
 However, at the moment the tests are totally isolated and you don't need a cluster to run them.
 
-We're currently supporting **Go 1.13**.
-
 ### Prerequisites
 
-1. The project needs to be cloned at `$GOPATH/src/github.com/newrelic/nri-prometheus`.
-2. Ensure you added `$GOPATH/bin` to your `$PATH`, otherwise builds won't be possible.
+1. **Go 1.13**. This project uses the [error
+   wrapping](https://golang.org/doc/go1.13#error_wrapping) support, which makes
+   it incompatible with previous Go versions.
+2. The project needs to be cloned at `$GOPATH/src/github.com/newrelic/nri-prometheus`.
+3. Ensure you added `$GOPATH/bin` to your `$PATH`, otherwise builds won't be possible.
 
 If you want to learn more about the GOPATH, check the [official Go docs](https://golang.org/doc/code.html#GOPATH).
 

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -54,6 +54,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("emitter_harvest_period", "1s")
 	viper.SetDefault("auto_decorate", false)
 	viper.SetDefault("insecure_skip_verify", false)
+	viper.SetDefault("percentiles", []float64{50.0, 95.0, 99.0})
 }
 
 // bindViperEnv automatically binds the variables in given configuration struct to environment variables.

--- a/internal/histogram/bucket.go
+++ b/internal/histogram/bucket.go
@@ -1,0 +1,27 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package histogram
+
+// Bucket represents a single grouping of values from Prometheus histogram metrics.
+type Bucket struct {
+	UpperBound float64
+	Count      float64
+}
+
+// Buckets implements sort.Interface.
+type Buckets []Bucket
+
+func (b Buckets) Len() int           { return len(b) }
+func (b Buckets) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b Buckets) Less(i, j int) bool { return b[i].UpperBound < b[j].UpperBound }

--- a/internal/histogram/percentile.go
+++ b/internal/histogram/percentile.go
@@ -116,7 +116,6 @@ func coalesceBuckets(buckets Buckets) Buckets {
 // As a somewhat hacky solution until ingestion is atomic per scrape, we
 // calculate the "envelope" of the histogram buckets, essentially removing
 // any decreases in the count between successive buckets.
-
 func ensureMonotonic(buckets Buckets) {
 	max := buckets[0].Count
 	for i := range buckets[1:] {

--- a/internal/histogram/percentile.go
+++ b/internal/histogram/percentile.go
@@ -1,0 +1,130 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package histogram
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+)
+
+// Percentile calculates the percentile `p` based on the buckets. The
+// buckets will be sorted by this function (i.e. no sorting needed before
+// calling this function). The percentile value is interpolated assuming a
+// linear distribution within a bucket. However, if the percentile falls
+// into the highest bucket, the upper bound of the 2nd highest bucket is
+// returned. A natural lower bound of 0 is assumed if the upper bound of the
+// lowest bucket is greater 0. In that case, interpolation in the lowest
+// bucket happens linearly between 0 and the upper bound of the lowest
+// bucket. However, if the lowest bucket has an upper bound less or equal to
+// 0, this upper bound is returned if the percentile falls into the lowest
+// bucket.
+//
+// An error is returned if:
+//  * `buckets` has fewer than 2 elements
+//  * the highest bucket is not +Inf
+//  * p<0
+//  * p>100
+func Percentile(p float64, buckets Buckets) (float64, error) {
+	if p < 0.0 {
+		return 0, fmt.Errorf("invalid percentile: %g (must be greater than 0.0)", p)
+	}
+	if p > 100.0 {
+		return 0, fmt.Errorf("invalid percentile: %g (must be less than 100.0)", p)
+	}
+	if len(buckets) < 2 {
+		return 0, fmt.Errorf("invalid buckets: minimum of 2 buckets required, got %d", len(buckets))
+	}
+	sort.Sort(buckets)
+	if !math.IsInf(buckets[len(buckets)-1].UpperBound, +1) {
+		return 0, errors.New("invalid buckets: highest bucket is not +Inf")
+	}
+
+	buckets = coalesceBuckets(buckets)
+	ensureMonotonic(buckets)
+
+	rank := (p / 100.0) * buckets[len(buckets)-1].Count
+	b := sort.Search(len(buckets)-1, func(i int) bool { return buckets[i].Count >= rank })
+
+	if b == len(buckets)-1 {
+		return buckets[len(buckets)-2].UpperBound, nil
+	}
+	if b == 0 && buckets[0].UpperBound <= 0 {
+		return buckets[0].UpperBound, nil
+	}
+	var (
+		bucketStart float64
+		bucketEnd   = buckets[b].UpperBound
+		count       = buckets[b].Count
+	)
+	if b > 0 {
+		bucketStart = buckets[b-1].UpperBound
+		count -= buckets[b-1].Count
+		rank -= buckets[b-1].Count
+	}
+	return bucketStart + (bucketEnd-bucketStart)*(rank/count), nil
+}
+
+// coalesceBuckets merges buckets with the same upper bound.
+//
+// The input buckets must be sorted.
+func coalesceBuckets(buckets Buckets) Buckets {
+	last := buckets[0]
+	i := 0
+	for _, b := range buckets[1:] {
+		if b.UpperBound == last.UpperBound {
+			last.Count += b.Count
+		} else {
+			buckets[i] = last
+			last = b
+			i++
+		}
+	}
+	buckets[i] = last
+	return buckets[:i+1]
+}
+
+// The assumption that bucket counts increase monotonically with increasing
+// UpperBound may be violated during:
+//
+//   * Recording rule evaluation of histogram_quantile, especially when rate()
+//      has been applied to the underlying bucket timeseries.
+//   * Evaluation of histogram_quantile computed over federated bucket
+//      timeseries, especially when rate() has been applied.
+//
+// This is because scraped data is not made available to rule evaluation or
+// federation atomically, so some buckets are computed with data from the
+// most recent scrapes, but the other buckets are missing data from the most
+// recent scrape.
+//
+// Monotonicity is usually guaranteed because if a bucket with upper bound
+// u1 has count c1, then any bucket with a higher upper bound u > u1 must
+// have counted all c1 observations and perhaps more, so that c  >= c1.
+//
+// As a somewhat hacky solution until ingestion is atomic per scrape, we
+// calculate the "envelope" of the histogram buckets, essentially removing
+// any decreases in the count between successive buckets.
+
+func ensureMonotonic(buckets Buckets) {
+	max := buckets[0].Count
+	for i := range buckets[1:] {
+		switch {
+		case buckets[i].Count > max:
+			max = buckets[i].Count
+		case buckets[i].Count < max:
+			buckets[i].Count = max
+		}
+	}
+}

--- a/internal/histogram/percentile_test.go
+++ b/internal/histogram/percentile_test.go
@@ -1,0 +1,130 @@
+package histogram
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEnsureMonotonic(t *testing.T) {
+	buckets := Buckets{
+		{0.5, 2.0},
+		{1.0, 1.0},
+		{2.0, 3.0},
+	}
+
+	ensureMonotonic(buckets)
+
+	expectedCounts := []float64{2.0, 2.0, 3.0}
+	for i, want := range expectedCounts {
+		if got := buckets[i].Count; got != want {
+			t.Errorf("ensureMonotonic failed to ensure monotonicity: buckets[%d] = %f; want %f", i, got, want)
+		}
+	}
+
+	// Run again to ensure nothing changes for a valid Buckets.
+	ensureMonotonic(buckets)
+	for i, want := range expectedCounts {
+		if got := buckets[i].Count; got != want {
+			t.Errorf("ensureMonotonic modified valid monotonicity: buckets[%d] = %f; want %f", i, got, want)
+		}
+	}
+}
+
+func TestCoalesceBuckets(t *testing.T) {
+	tests := []struct {
+		input Buckets
+		want  Buckets
+	}{
+		{
+			Buckets{{0.5, 1.0}, {0.5, 2.0}},
+			Buckets{{0.5, 3.0}},
+		},
+		{
+			Buckets{{0.5, 1.0}, {0.5, 2.0}, {1.0, 3.0}},
+			Buckets{{0.5, 3.0}, {1.0, 3.0}},
+		},
+		{
+			Buckets{{0.1, 1.0}, {0.5, 1.0}, {0.5, 2.0}, {1.0, 3.0}},
+			Buckets{{0.1, 1.0}, {0.5, 3.0}, {1.0, 3.0}},
+		},
+	}
+
+	for _, test := range tests {
+		coalesced := coalesceBuckets(test.input)
+		if len(coalesced) != len(test.want) {
+			t.Errorf("coalesceBuckets failed to coalesce to desired length %d; got %d", len(test.want), len(coalesced))
+			continue
+		}
+		for i, got := range coalesced {
+			want := test.want[i]
+			if got.UpperBound != want.UpperBound || got.Count != want.Count {
+				t.Errorf("coalesceBuckets failed to coalesce element %d: got %#v; want %#v", i, got, want)
+			}
+		}
+	}
+}
+
+func TestPercentileValidatesInput(t *testing.T) {
+	tests := []struct {
+		p       float64
+		buckets Buckets
+	}{
+		// p < 0.0
+		{-1.0, Buckets{}},
+		// p > 100.0
+		{101.0, Buckets{}},
+		// len(buckets) < 2
+		{50.0, Buckets{}},
+		// len(buckets) < 2
+		{50.0, Buckets{{math.Inf(1), 1.0}}},
+		// Last bucket is not +Inf
+		{50.0, Buckets{{0.5, 1.0}, {1.0, 2.0}}},
+	}
+
+	for _, test := range tests {
+		if _, err := Percentile(test.p, test.buckets); err == nil {
+			t.Errorf("Percentile(%g, %#v) did not return an error", test.p, test.buckets)
+		}
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	buckets := Buckets{
+		{-20.0, 10.0},
+		{1.0, 11.0},
+		{40.0, 20.0},
+		{200.0, 200.0},
+		{math.Inf(1), 220.0},
+	}
+
+	tests := []struct {
+		p    float64
+		want float64
+	}{
+		{0.0, -20.0},
+		{4.0, -20.0},
+		{5.0, 1.0},
+		{50.0, 120},
+		{99.0, 200.0},
+		{100.0, 200.0},
+	}
+
+	for _, test := range tests {
+		if got, _ := Percentile(test.p, buckets); got != test.want {
+			t.Errorf("Percentile(%g, %v) = %g; want %g", test.p, buckets, got, test.want)
+		}
+	}
+}
+
+var benchmarkBuckets = Buckets{
+	{10.0, 10.0},
+	{20.0, 20.0},
+	{30.0, 30.0},
+	{math.Inf(1), 30.0},
+}
+
+func BenchmarkPercentile(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = Percentile(0.5, benchmarkBuckets)
+	}
+}

--- a/internal/histogram/percentile_test.go
+++ b/internal/histogram/percentile_test.go
@@ -1,3 +1,16 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package histogram
 
 import (

--- a/internal/integration/emitter.go
+++ b/internal/integration/emitter.go
@@ -12,7 +12,7 @@ import (
 	"github.com/newrelic/go-telemetry-sdk/cumulative"
 	"github.com/newrelic/go-telemetry-sdk/telemetry"
 	"github.com/newrelic/nri-prometheus/internal/histogram"
-	mpb "github.com/prometheus/client_model/go"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -178,7 +178,7 @@ func (te *TelemetryEmitter) Emit(metrics []Metric) error {
 // Related specification:
 // https://github.com/newrelic/newrelic-exporter-specs/blob/master/Guidelines.md#percentiles
 func (te *TelemetryEmitter) emitSummary(metric Metric, timestamp time.Time) error {
-	summary, ok := metric.value.(*mpb.Summary)
+	summary, ok := metric.value.(*dto.Summary)
 	if !ok {
 		return fmt.Errorf("unknown summary metric type for %q: %T", metric.name, metric.value)
 	}
@@ -227,7 +227,7 @@ func (te *TelemetryEmitter) emitSummary(metric Metric, timestamp time.Time) erro
 // Related specification:
 // https://github.com/newrelic/newrelic-exporter-specs/blob/master/Guidelines.md#histograms
 func (te *TelemetryEmitter) emitHistogram(metric Metric, timestamp time.Time) error {
-	hist, ok := metric.value.(*mpb.Histogram)
+	hist, ok := metric.value.(*dto.Histogram)
 	if !ok {
 		return fmt.Errorf("unknown histogram metric type for %q: %T", metric.name, metric.value)
 	}

--- a/internal/integration/emitter.go
+++ b/internal/integration/emitter.go
@@ -175,7 +175,8 @@ func (te *TelemetryEmitter) Emit(metrics []Metric) error {
 
 // emitSummary sends all quantiles included with the summary as percentiles to New Relic.
 //
-// Related specification: https://source.datanerd.us/agents/exporter-specs/blob/master/Guidelines.md
+// Related specification:
+// https://github.com/newrelic/newrelic-exporter-specs/blob/master/Guidelines.md#percentiles
 func (te *TelemetryEmitter) emitSummary(metric Metric, timestamp time.Time) error {
 	summary, ok := metric.value.(*mpb.Summary)
 	if !ok {
@@ -221,9 +222,10 @@ func (te *TelemetryEmitter) emitSummary(metric Metric, timestamp time.Time) erro
 	return results
 }
 
-// emitHistogram sends histogram data and currated percentiles to New Relic.
+// emitHistogram sends histogram data and curated percentiles to New Relic.
 //
-// Related specification: https://source.datanerd.us/agents/exporter-specs/blob/master/Guidelines.md
+// Related specification:
+// https://github.com/newrelic/newrelic-exporter-specs/blob/master/Guidelines.md#histograms
 func (te *TelemetryEmitter) emitHistogram(metric Metric, timestamp time.Time) error {
 	hist, ok := metric.value.(*mpb.Histogram)
 	if !ok {

--- a/internal/integration/emitter_test.go
+++ b/internal/integration/emitter_test.go
@@ -4,18 +4,25 @@ package integration
 
 import (
 	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
 	"testing"
 
+	"github.com/newrelic/go-telemetry-sdk/telemetry"
+	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
+	mpb "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/newrelic/go-telemetry-sdk/telemetry"
+	"github.com/newrelic/nri-prometheus/internal/pkg/labels"
 	"github.com/newrelic/nri-prometheus/internal/pkg/prometheus"
 )
 
@@ -48,6 +55,7 @@ func BenchmarkTelemetrySDKEmitter(b *testing.B) {
 			func(cfg *telemetry.Config) {
 				cfg.Client.Transport = nilRoundTripper()
 			},
+			telemetry.ConfigAPIKey("api key"),
 			TelemetryHarvesterWithMetricsURL("nilapiurl"),
 			telemetry.ConfigBasicErrorLogger(os.Stdout),
 		},
@@ -102,4 +110,300 @@ func decodePromMetrics(src io.Reader) (*prometheus.MetricFamiliesByName, error) 
 		mfs[mf.GetName()] = mf
 	}
 	return &mfs, nil
+}
+
+func TestTelemetryEmitterEmit(t *testing.T) {
+	hist, err := newHistogram([]int64{0, 0, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := newSummary(3, 10, []*quantile{{0.5, 10}, {0.999, 100}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metrics := []Metric{
+		{
+			name:       "common-name",
+			metricType: metricType_COUNTER,
+			value:      float64(1),
+			attributes: labels.Set{
+				"name":           "common-name",
+				"targetName":     "target-a",
+				"nrMetricType":   "count",
+				"promMetricType": "counter",
+			},
+		},
+		{
+			name:       "common-name2",
+			metricType: metricType_COUNTER,
+			value:      float64(1),
+			attributes: labels.Set{
+				"name":           "common-name2",
+				"targetName":     "target-b",
+				"nrMetricType":   "count",
+				"promMetricType": "counter",
+			},
+		},
+		{
+			name:       "common-name3",
+			metricType: metricType_GAUGE,
+			value:      float64(1),
+			attributes: labels.Set{
+				"name":           "common-name3",
+				"targetName":     "target-c",
+				"nrMetricType":   "gauge",
+				"promMetricType": "gauge",
+			},
+		},
+		{
+			name:       "histogram-1",
+			metricType: metricType_HISTOGRAM,
+			value:      hist,
+			attributes: labels.Set{
+				"name":           "histogram-1",
+				"targetName":     "target-d",
+				"nrMetricType":   "histogram",
+				"promMetricType": "histogram",
+			},
+		},
+		{
+			name:       "summary-1",
+			metricType: metricType_SUMMARY,
+			value:      summary,
+			attributes: labels.Set{},
+		},
+	}
+
+	var rawMetrics []interface{}
+	c := TelemetryEmitterConfig{
+		HarvesterOpts: []TelemetryHarvesterOpt{
+			telemetry.ConfigAPIKey("api key"),
+			TelemetryHarvesterWithMetricsURL("nilapiurl"),
+			func(cfg *telemetry.Config) {
+				cfg.Client.Transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					var reader io.ReadCloser
+					// The telemetry SDK sends encoded data, but be safe and check
+					switch req.Header.Get("Content-Encoding") {
+					case "gzip":
+						var err error
+						if reader, err = gzip.NewReader(req.Body); err != nil {
+							t.Fatal(err)
+						}
+						defer func() {
+							_ = reader.Close()
+						}()
+					default:
+						reader = ioutil.NopCloser(req.Body)
+					}
+					var decoder []map[string]interface{}
+					if err := json.NewDecoder(reader).Decode(&decoder); err != nil {
+						t.Fatal(err)
+					}
+					var ok bool
+					if rawMetrics, ok = decoder[0]["metrics"].([]interface{}); !ok {
+						t.Fatal(errors.New("failed to decode telemetry post request body metrics"))
+					}
+
+					return emptyResponse(200), nil
+				})
+			},
+			telemetry.ConfigBasicErrorLogger(os.Stdout),
+		},
+		Percentiles: []float64{50.0},
+	}
+
+	e := NewTelemetryEmitter(c)
+
+	// Emit and force a harvest to clear.
+	assert.NoError(t, e.Emit(metrics))
+	e.harvester.HarvestNow()
+
+	// Set new histogram values so counts will be non-zero.
+	hist2, err := newHistogram([]int64{1, 2, 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	*hist = *hist2
+
+	// Run twice so delta counts are sent.
+	assert.NoError(t, e.Emit(metrics))
+	e.harvester.HarvestNow()
+	purgeTimestamps(rawMetrics)
+
+	expectedMetrics := []interface{}{
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"name":           "common-name",
+				"nrMetricType":   "count",
+				"promMetricType": "counter",
+				"targetName":     "target-a",
+			},
+			"name":  "common-name",
+			"type":  "count",
+			"value": float64(0),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"name":           "common-name2",
+				"nrMetricType":   "count",
+				"promMetricType": "counter",
+				"targetName":     "target-b",
+			},
+			"name":  "common-name2",
+			"type":  "count",
+			"value": float64(0),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"name":           "common-name3",
+				"nrMetricType":   "gauge",
+				"promMetricType": "gauge",
+				"targetName":     "target-c",
+			},
+			"name":  "common-name3",
+			"type":  "gauge",
+			"value": float64(1),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"name":           "histogram-1",
+				"targetName":     "target-d",
+				"nrMetricType":   "histogram",
+				"promMetricType": "histogram",
+			},
+			"name":  "histogram-1.sum",
+			"type":  "count",
+			"value": float64(10),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"name":                        "histogram-1",
+				"targetName":                  "target-d",
+				"nrMetricType":                "histogram",
+				"promMetricType":              "histogram",
+				"histogram.bucket.upperBound": float64(0),
+			},
+			"name":  "histogram-1.buckets",
+			"type":  "count",
+			"value": float64(1),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"name":                        "histogram-1",
+				"targetName":                  "target-d",
+				"nrMetricType":                "histogram",
+				"promMetricType":              "histogram",
+				"histogram.bucket.upperBound": float64(1),
+			},
+			"name":  "histogram-1.buckets",
+			"type":  "count",
+			"value": float64(2),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"name":           "histogram-1",
+				"targetName":     "target-d",
+				"nrMetricType":   "histogram",
+				"promMetricType": "histogram",
+				"percentile":     float64(50),
+			},
+			"name":  "histogram-1.percentiles",
+			"type":  "gauge",
+			"value": float64(1),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"percentile": float64(50),
+			},
+			"name":  "summary-1.percentiles",
+			"type":  "gauge",
+			"value": float64(10),
+		},
+		map[string]interface{}{
+			"attributes": map[string]interface{}{
+				"percentile": float64(99.9),
+			},
+			"name":  "summary-1.percentiles",
+			"type":  "gauge",
+			"value": float64(100),
+		},
+	}
+	assert.Equal(t, expectedMetrics, rawMetrics)
+}
+
+// quantile groups Quantile values so they can be passed as an ordered pair.
+type quantile struct {
+	Quantile float64
+	Value    float64
+}
+
+// newSummary returns a Prometheus Summary for testing.
+func newSummary(count uint64, sum float64, quantiles []*quantile) (*mpb.Summary, error) {
+	raw := fmt.Sprintf(`{
+		"sample_count": %d,
+		"sample_sum": %g,
+		"quantile": [`, count, float64(sum))
+	for i, q := range quantiles {
+		raw += fmt.Sprintf(`{"quantile": %g, "value": %g}`, q.Quantile, q.Value)
+		if i != len(quantiles)-1 {
+			raw += ","
+		}
+	}
+	raw += `]
+	}`
+
+	summary := &mpb.Summary{}
+	if err := json.Unmarshal([]byte(raw), summary); err != nil {
+		return nil, err
+	}
+	return summary, nil
+}
+
+// newHistogram returns a Prometheus Histogram for testing.
+func newHistogram(buckets []int64) (*mpb.Histogram, error) {
+	count := len(buckets)
+	sum := buckets[count-1]
+	raw := fmt.Sprintf(`{
+		"sample_count": %d,
+		"sample_sum": %g,
+		"bucket": [`, count, float64(sum))
+	for i, v := range buckets {
+		raw += fmt.Sprintf(`{"upper_bound": %g, "cumulative_count": %d}`, float64(i), v)
+		if i != count-1 {
+			raw += ","
+		}
+	}
+	raw += `]
+	}`
+
+	hist := &mpb.Histogram{}
+	if err := json.Unmarshal([]byte(raw), hist); err != nil {
+		return nil, err
+	}
+
+	// Work around infinity not being supported in JSON.
+	inf := math.Inf(1)
+	hist.Bucket[count-1].UpperBound = &inf
+
+	return hist, nil
+}
+
+// purgeTimestamps removes all `timestamp` amd `interval.ms` key/values
+// from metrics.
+//
+// The passed metrics are the raw values the telemetry SDK passes to
+// New Relic (hence no struct). This structure keeps the "timestamp"
+// and "interval.ms" keys at the top-level of each "metric" in the
+// interface{} slice.
+func purgeTimestamps(metrics []interface{}) {
+	for _, m := range metrics {
+		assertedM, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		delete(assertedM, "timestamp")
+		delete(assertedM, "interval.ms")
+	}
 }

--- a/internal/integration/fetcher_test.go
+++ b/internal/integration/fetcher_test.go
@@ -187,6 +187,66 @@ func TestConvertPromMetrics(t *testing.T) {
 						},
 					},
 				},
+				"histogram_example": dto.MetricFamily{
+					// use anonymous struct to return *dto.MetricType literal.
+					Type: &(&struct{ x dto.MetricType }{dto.MetricType_HISTOGRAM}).x,
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									// use anonymous struct to return *string literal.
+									Name:  &(&struct{ x string }{"histLabelName"}).x,
+									Value: &(&struct{ x string }{"histLabelValue"}).x,
+								},
+							},
+							Histogram: &dto.Histogram{
+								// use anonymous struct to return *float64 literal.
+								SampleCount: &(&struct{ x uint64 }{10}).x,
+								SampleSum:   &(&struct{ x float64 }{42}).x,
+								Bucket: []*dto.Bucket{
+									&dto.Bucket{
+										CumulativeCount: &(&struct{ x uint64 }{42}).x,
+										UpperBound:      &(&struct{ x float64 }{100}).x,
+									},
+									&dto.Bucket{
+										CumulativeCount: &(&struct{ x uint64 }{24}).x,
+										UpperBound:      &(&struct{ x float64 }{50}).x,
+									},
+								},
+							},
+						},
+					},
+				},
+				"summary_example": dto.MetricFamily{
+					// use anonymous struct to return *dto.MetricType literal.
+					Type: &(&struct{ x dto.MetricType }{dto.MetricType_SUMMARY}).x,
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									// use anonymous struct to return *string literal.
+									Name:  &(&struct{ x string }{"summaryLabelName"}).x,
+									Value: &(&struct{ x string }{"summaryLabelValue"}).x,
+								},
+							},
+							Summary: &dto.Summary{
+								// use anonymous struct to return *float64 and *unint64 literal.
+								SampleCount: &(&struct{ x uint64 }{10}).x,
+								SampleSum:   &(&struct{ x float64 }{42}).x,
+								Quantile: []*dto.Quantile{
+									&dto.Quantile{
+										Quantile: &(&struct{ x float64 }{0.5}).x,
+										Value:    &(&struct{ x float64 }{100}).x,
+									},
+									&dto.Quantile{
+										Quantile: &(&struct{ x float64 }{0.9}).x,
+										Value:    &(&struct{ x float64 }{200}).x,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			[]Metric{
 				{
@@ -209,6 +269,56 @@ func TestConvertPromMetrics(t *testing.T) {
 						"targetName":     "hotdog-stand",
 						"nrMetricType":   "gauge",
 						"promMetricType": "gauge",
+					},
+				},
+				{
+					name:       "histogram_example",
+					metricType: metricType_HISTOGRAM,
+					value: &dto.Histogram{
+						// use anonymous struct to return *float64 literal.
+						SampleCount: &(&struct{ x uint64 }{10}).x,
+						SampleSum:   &(&struct{ x float64 }{42}).x,
+						Bucket: []*dto.Bucket{
+							&dto.Bucket{
+								CumulativeCount: &(&struct{ x uint64 }{42}).x,
+								UpperBound:      &(&struct{ x float64 }{100}).x,
+							},
+							&dto.Bucket{
+								CumulativeCount: &(&struct{ x uint64 }{24}).x,
+								UpperBound:      &(&struct{ x float64 }{50}).x,
+							},
+						},
+					},
+					attributes: labels.Set{
+						"histLabelName":  "histLabelValue",
+						"targetName":     "hotdog-stand",
+						"nrMetricType":   "histogram",
+						"promMetricType": "histogram",
+					},
+				},
+				{
+					name:       "summary_example",
+					metricType: metricType_SUMMARY,
+					value: &dto.Summary{
+						// use anonymous struct to return *float64 literal.
+						SampleCount: &(&struct{ x uint64 }{10}).x,
+						SampleSum:   &(&struct{ x float64 }{42}).x,
+						Quantile: []*dto.Quantile{
+							&dto.Quantile{
+								Quantile: &(&struct{ x float64 }{0.5}).x,
+								Value:    &(&struct{ x float64 }{100}).x,
+							},
+							&dto.Quantile{
+								Quantile: &(&struct{ x float64 }{0.9}).x,
+								Value:    &(&struct{ x float64 }{200}).x,
+							},
+						},
+					},
+					attributes: labels.Set{
+						"summaryLabelName": "summaryLabelValue",
+						"targetName":       "hotdog-stand",
+						"nrMetricType":     "summary",
+						"promMetricType":   "summary",
 					},
 				},
 			},
@@ -249,6 +359,66 @@ func TestConvertPromMetrics(t *testing.T) {
 						},
 					},
 				},
+				"histogram_example": dto.MetricFamily{
+					// use anonymous struct to return *dto.MetricType literal.
+					Type: &(&struct{ x dto.MetricType }{dto.MetricType_HISTOGRAM}).x,
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									// use anonymous struct to return *string literal.
+									Name:  &(&struct{ x string }{"histLabelName"}).x,
+									Value: &(&struct{ x string }{"histLabelValue"}).x,
+								},
+							},
+							Histogram: &dto.Histogram{
+								// use anonymous struct to return *float64 literal.
+								SampleCount: &(&struct{ x uint64 }{20}).x,
+								SampleSum:   &(&struct{ x float64 }{52}).x,
+								Bucket: []*dto.Bucket{
+									&dto.Bucket{
+										CumulativeCount: &(&struct{ x uint64 }{52}).x,
+										UpperBound:      &(&struct{ x float64 }{200}).x,
+									},
+									&dto.Bucket{
+										CumulativeCount: &(&struct{ x uint64 }{34}).x,
+										UpperBound:      &(&struct{ x float64 }{60}).x,
+									},
+								},
+							},
+						},
+					},
+				},
+				"summary_example": dto.MetricFamily{
+					// use anonymous struct to return *dto.MetricType literal.
+					Type: &(&struct{ x dto.MetricType }{dto.MetricType_SUMMARY}).x,
+					Metric: []*dto.Metric{
+						{
+							Label: []*dto.LabelPair{
+								{
+									// use anonymous struct to return *string literal.
+									Name:  &(&struct{ x string }{"summaryLabelName"}).x,
+									Value: &(&struct{ x string }{"summaryLabelValue"}).x,
+								},
+							},
+							Summary: &dto.Summary{
+								// use anonymous struct to return *float64 and *unint64 literal.
+								SampleCount: &(&struct{ x uint64 }{20}).x,
+								SampleSum:   &(&struct{ x float64 }{52}).x,
+								Quantile: []*dto.Quantile{
+									&dto.Quantile{
+										Quantile: &(&struct{ x float64 }{0.5}).x,
+										Value:    &(&struct{ x float64 }{42}).x,
+									},
+									&dto.Quantile{
+										Quantile: &(&struct{ x float64 }{0.9}).x,
+										Value:    &(&struct{ x float64 }{24}).x,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			[]Metric{
 				{
@@ -271,6 +441,56 @@ func TestConvertPromMetrics(t *testing.T) {
 						"targetName":     "hotdog-stand",
 						"nrMetricType":   "gauge",
 						"promMetricType": "gauge",
+					},
+				},
+				{
+					name:       "histogram_example",
+					metricType: metricType_HISTOGRAM,
+					value: &dto.Histogram{
+						// use anonymous struct to return *float64 literal.
+						SampleCount: &(&struct{ x uint64 }{20}).x,
+						SampleSum:   &(&struct{ x float64 }{52}).x,
+						Bucket: []*dto.Bucket{
+							&dto.Bucket{
+								CumulativeCount: &(&struct{ x uint64 }{52}).x,
+								UpperBound:      &(&struct{ x float64 }{200}).x,
+							},
+							&dto.Bucket{
+								CumulativeCount: &(&struct{ x uint64 }{34}).x,
+								UpperBound:      &(&struct{ x float64 }{60}).x,
+							},
+						},
+					},
+					attributes: labels.Set{
+						"histLabelName":  "histLabelValue",
+						"targetName":     "hotdog-stand",
+						"nrMetricType":   "histogram",
+						"promMetricType": "histogram",
+					},
+				},
+				{
+					name:       "summary_example",
+					metricType: metricType_SUMMARY,
+					value: &dto.Summary{
+						// use anonymous struct to return *float64 and *unint64 literal.
+						SampleCount: &(&struct{ x uint64 }{20}).x,
+						SampleSum:   &(&struct{ x float64 }{52}).x,
+						Quantile: []*dto.Quantile{
+							&dto.Quantile{
+								Quantile: &(&struct{ x float64 }{0.5}).x,
+								Value:    &(&struct{ x float64 }{42}).x,
+							},
+							&dto.Quantile{
+								Quantile: &(&struct{ x float64 }{0.9}).x,
+								Value:    &(&struct{ x float64 }{24}).x,
+							},
+						},
+					},
+					attributes: labels.Set{
+						"summaryLabelName": "summaryLabelValue",
+						"targetName":       "hotdog-stand",
+						"nrMetricType":     "summary",
+						"promMetricType":   "summary",
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds support for processing summaries and histograms.

Most of the work of this PR was made by @MrAlias when the project was hosted on a private repository, so all the credit should go to him, I just rebased, and did some minor improvements.

The implementation follows the the [New Relic's guidelines for higher-level metric abstractions](https://github.com/newrelic/newrelic-exporter-specs/blob/master/Guidelines.md):

- For summaries, the quantiles are transformed and sent as percentiles.
- For histograms, predefined percentiles are calculated and sent along with the buckets. By default the 50, 95 and 99 percentile are calculated, this value can be overriden via the `percentiles` configuration option. 

The `histogram` package had to be copied from the official prometheus one, because the data structures and methods used are private in the official repo. Also, some changes were made to calculate percentiles instead of quantiles.