### PR TITLE
Documentation improvements and matching with the codebase

### DIFF
--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -49,7 +49,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("emitters", []string{"telemetry"})
 	viper.SetDefault("scrape_enabled_label", "prometheus.io/scrape")
 	viper.SetDefault("require_scrape_enabled_label_for_nodes", false)
-	viper.SetDefault("scrape_timeout", time.Duration(5000000000))
+	viper.SetDefault("scrape_timeout", 5*time.Second)
 	viper.SetDefault("scrape_duration", "30s")
 	viper.SetDefault("emitter_harvest_period", "1s")
 	viper.SetDefault("auto_decorate", false)

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -48,7 +48,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("verbose", false)
 	viper.SetDefault("emitters", []string{"telemetry"})
 	viper.SetDefault("scrape_enabled_label", "prometheus.io/scrape")
-	viper.SetDefault("require_scrape_enabled_label_for_nodes", false)
+	viper.SetDefault("require_scrape_enabled_label_for_nodes", true)
 	viper.SetDefault("scrape_timeout", 5*time.Second)
 	viper.SetDefault("scrape_duration", "30s")
 	viper.SetDefault("emitter_harvest_period", "1s")

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -92,7 +92,7 @@ data:
     insecure_skip_verify: false
     # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
     scrape_enabled_label: "prometheus.io/scrape"
-    # Whether k8s nodes needs to be labelled to be scraped or not. Defaults to false.
+    # Whether k8s nodes needs to be labelled to be scraped or not. Defaults to true.
     require_scrape_enabled_label_for_nodes: true
     #targets:
     #  - description: Secure etcd example

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -92,7 +92,7 @@ data:
     insecure_skip_verify: false
     # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
     scrape_enabled_label: "prometheus.io/scrape"
-    # Whether k8s nodes needs to be labelled to be scraped or not. Defaults to true.
+    # Whether k8s nodes need to be labelled to be scraped or not. Defaults to true.
     require_scrape_enabled_label_for_nodes: true
     #targets:
     #  - description: Secure etcd example

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -84,8 +84,8 @@ data:
     cluster_name: "<YOUR_CLUSTER_NAME>"
     # How often the integration should run. Defaults to 30s.
     # scrape_duration: "30s"
-    # The HTTP client timeout when fetching data from endpoints. Defaults to 30s.
-    # scrape_timeout: "30s"
+    # The HTTP client timeout when fetching data from endpoints. Defaults to 5s.
+    # scrape_timeout: "5s"
     # Wether the integration should run in verbose mode or not. Defaults to false.
     verbose: false
     # Wether the integration should skip TLS verification or not. Defaults to false.

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -92,7 +92,7 @@ data:
     insecure_skip_verify: false
     # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
     scrape_enabled_label: "prometheus.io/scrape"
-    # Wether k8s nodes needs to be labelled to be scraped or not. Defaults to false.
+    # Whether k8s nodes needs to be labelled to be scraped or not. Defaults to false.
     require_scrape_enabled_label_for_nodes: true
     #targets:
     #  - description: Secure etcd example


### PR DESCRIPTION
* Better representation of the scrape timeout default value
* Fix the scrape timeout default value in the example configuration
* Fix the default value of `require_scrape_enabled_label_for_nodes` to match what is said in the default configuration