### PR TITLE
FSI-1155: Don't scrape pods without a valid PodIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   deploy manifest template is commented by default. It's left in the manifest
   as an example on how to use transformations. Installing with the new manifest
   will not filter metrics and everything will be sent to the New Relic platform.
+  
+### Fixed
+- Fixed a bug that caused newly created pods without a valid podIP to be discovered 
+  and cached, and not be scraped unless nri-prometheus was restarted. 
 
 ## 1.2.1
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,3 +52,16 @@ deploy/local.yaml.example to deploy/local.yaml and edit the placeholders.
    `https://newrelic.com/accounts/<YOUR_ACCOUNT_ID>`. It's located in the right sidebar.
 - After updating the yaml file, you need to compile the integration: `GOOS=linux make compile-only`.
 - Once you have it compiled, you need to deploy it in your Kubernetes cluster: `skaffold run`
+
+### Running the Kubernetes Target Retriever locally
+
+It can be useful to run the Kubernetes Target Retriever locally against a remote/local cluster to debug the endpoints that are discovered.
+The program located in `/cmd/k8s-target-retriever` is made for this.
+
+To run the program, go to `cmd/k8s-target-retriever` in your terminal, and run the following command:
+```shell script
+# ensure your kubectl is configured correcly & against the correct clusters
+kubectl config get-contexts
+# run the program 
+go run * -kubeconfig ~/.kube/config 
+``` 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ deploy/local.yaml.example to deploy/local.yaml and edit the placeholders.
 It can be useful to run the Kubernetes Target Retriever locally against a remote/local cluster to debug the endpoints that are discovered.
 The program located in `/cmd/k8s-target-retriever` is made for this.
 
-To run the program, go to `cmd/k8s-target-retriever` in your terminal, and run the following command:
+To run the program,run the following command in your terminal:
 ```shell script
-# ensure your kubectl is configured correcly & against the correct clusters
+# ensure your kubectl is configured correcly & against the correct cluster
 kubectl config get-contexts
 # run the program 
-go run * -kubeconfig ~/.kube/config 
+go run cmd/k8s-target-retriever/main.go
 ``` 

--- a/cmd/k8s-target-retriever/main.go
+++ b/cmd/k8s-target-retriever/main.go
@@ -4,14 +4,17 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
+
+	"github.com/kubernetes/client-go/util/homedir"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/nri-prometheus/internal/pkg/endpoints"
 )
 
-var kubeConfigFile = flag.String("kubeconfig", "", "location of the kube config file")
+var kubeConfigFile = flag.String("kubeconfig", "", "location of the kube config file. Defaults to ~/.kube/config")
 
 func init() {
 	flag.Usage = func() {
@@ -24,6 +27,10 @@ func init() {
 }
 func main() {
 	flag.Parse()
+
+	if *kubeConfigFile == "" {
+		*kubeConfigFile = filepath.Join(homedir.HomeDir(), ".kube", "config")
+	}
 
 	kubeconf := endpoints.WithKubeConfig(*kubeConfigFile)
 	ktr, err := endpoints.NewKubernetesTargetRetriever("prometheus.io/scrape", false, kubeconf)

--- a/cmd/k8s-target-retriever/main.go
+++ b/cmd/k8s-target-retriever/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/newrelic/nri-prometheus/internal/pkg/endpoints"
+)
+
+var kubeConfigFile = flag.String("kubeconfig", "", "location of the kube config file")
+
+func init() {
+	flag.Usage = func() {
+		fmt.Printf("Usage of %s:\n", os.Args[0])
+		fmt.Println("")
+		fmt.Println("k8s-target-retriever is a simple helper program to run the KubernetesTargetRetriever logic on your own machine, for debugging purposes.")
+		fmt.Println("")
+		flag.PrintDefaults()
+	}
+}
+func main() {
+	flag.Parse()
+
+	kubeconf := endpoints.WithKubeConfig(*kubeConfigFile)
+	ktr, err := endpoints.NewKubernetesTargetRetriever("prometheus.io/scrape", false, kubeconf)
+	if err != nil {
+		logrus.Fatalf("could not create KubernetesTargetRetriever: %v", err)
+	}
+
+	if err := ktr.Watch(); err != nil {
+		logrus.Fatalf("could not watch for events: %v", err)
+	}
+
+	logrus.Infoln("connected to cluster, watching for targets")
+
+	for range time.Tick(time.Second * 5) {
+		targets, err := ktr.GetTargets()
+		if err != nil {
+			logrus.Fatalf("could not get targets: %v", err)
+		}
+		for _, b := range targets {
+			logrus.Infof("%s[%s] %s", b.Name, b.Object.Kind, b.URL.String())
+		}
+
+		logrus.Println()
+	}
+}

--- a/cmd/k8s-target-retriever/main.go
+++ b/cmd/k8s-target-retriever/main.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/kubernetes/client-go/util/homedir"
+	"k8s.io/client-go/util/homedir"
 
 	"github.com/sirupsen/logrus"
 

--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -127,7 +127,7 @@ func RunWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 	}
 	retrievers = append(retrievers, fixedRetriever)
 
-	kubernetesRetriever, err := endpoints.NewKubernetesTargetRetriever(cfg.ScrapeEnabledLabel, cfg.RequireScrapeEnabledLabelForNodes)
+	kubernetesRetriever, err := endpoints.NewKubernetesTargetRetriever(cfg.ScrapeEnabledLabel, cfg.RequireScrapeEnabledLabelForNodes, endpoints.WithInClusterConfig())
 	if err != nil {
 		logrus.WithError(err).Errorf("not possible to get a Kubernetes client. If you aren't running this integration in a Kubernetes cluster, you can ignore this error")
 	} else {

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -482,7 +482,6 @@ func (k *KubernetesTargetRetriever) processEvent(event watch.Event, requireLabel
 		// In some configurations this is the case for nodes.
 		if !requireLabel {
 			k.addTarget(object, event.Type)
-			debugLogEvent(klog, event.Type, "added", object)
 		}
 	case watch.Modified:
 		if requireLabel {

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -322,7 +322,7 @@ func WithKubeConfig(kubeConfigFile string) Option {
 }
 
 // WithInClusterConfig configures the KubernetesTargetRetriever to load the Kubernetes configuration
-// from a pod that is running in the cluster
+// from within a running pod in the cluster (/var/run/secrets/kubernetes.io/serviceaccount/*)
 func WithInClusterConfig() Option {
 	return func(ktr *KubernetesTargetRetriever) error {
 		config, err := rest.InClusterConfig()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1639,10 +1639,34 @@
 			"revisionTime": "2018-11-08T18:57:36Z"
 		},
 		{
+			"checksumSHA1": "hJpqbilBYNCvAqoKan4gqKLXADk=",
+			"path": "k8s.io/client-go/tools/auth",
+			"revision": "14c42cd304d9e112a51d79937759edbd3665305b",
+			"revisionTime": "2019-10-16T16:35:56Z"
+		},
+		{
+			"checksumSHA1": "7LorUheXLUJfJUmf6jsNu3P6sa4=",
+			"path": "k8s.io/client-go/tools/clientcmd",
+			"revision": "b1c1d2e7ca769cde6c9ce3c4aac53fde6ca5c5d9",
+			"revisionTime": "2018-11-08T18:57:36Z"
+		},
+		{
 			"checksumSHA1": "4KsMHoSucjQi0FW3kqkFIPgssyk=",
 			"path": "k8s.io/client-go/tools/clientcmd/api",
 			"revision": "b1c1d2e7ca769cde6c9ce3c4aac53fde6ca5c5d9",
 			"revisionTime": "2018-11-08T18:57:36Z"
+		},
+		{
+			"checksumSHA1": "REsiLFxKYUjcTcPnDBwgr4GkArg=",
+			"path": "k8s.io/client-go/tools/clientcmd/api/latest",
+			"revision": "14c42cd304d9e112a51d79937759edbd3665305b",
+			"revisionTime": "2019-10-16T16:35:56Z"
+		},
+		{
+			"checksumSHA1": "gOq6PL80JftrypouhV+xxbf/WUo=",
+			"path": "k8s.io/client-go/tools/clientcmd/api/v1",
+			"revision": "14c42cd304d9e112a51d79937759edbd3665305b",
+			"revisionTime": "2019-10-16T16:35:56Z"
 		},
 		{
 			"checksumSHA1": "rRC9GCWXfyIXKHBCeKpw7exVybE=",
@@ -1679,6 +1703,12 @@
 			"path": "k8s.io/client-go/util/flowcontrol",
 			"revision": "b1c1d2e7ca769cde6c9ce3c4aac53fde6ca5c5d9",
 			"revisionTime": "2018-11-08T18:57:36Z"
+		},
+		{
+			"checksumSHA1": "Xtfe96NvDi6//e4QRZVN+DOu3Xk=",
+			"path": "k8s.io/client-go/util/homedir",
+			"revision": "14c42cd304d9e112a51d79937759edbd3665305b",
+			"revisionTime": "2019-10-16T16:35:56Z"
 		},
 		{
 			"checksumSHA1": "W6bJiNAwgNwNJC+y+TPtacgUGlY=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -189,6 +189,12 @@
 			"revisionTime": "2019-06-11T12:32:18Z"
 		},
 		{
+			"checksumSHA1": "Krmcp9xkjW8RL0WOF+2ECVllrHw=",
+			"path": "github.com/imdario/mergo",
+			"revision": "1afb36080aec31e0d1528973ebe6721b191b0369",
+			"revisionTime": "2019-10-03T07:39:17Z"
+		},
+		{
 			"checksumSHA1": "W4cByvvu+jwClgwuAKbJn8vlDwI=",
 			"path": "github.com/json-iterator/go",
 			"revision": "05d041de1043ba04b678fb046bd35455a9b1b33b",


### PR DESCRIPTION
This PR fixes the bug that adds newly created Pod-targets without an ipAddress and caches them, which makes them unscrabable unless you restart POMI. 

It also includes a simple program that runs the KubernetesTargetRetriever locally so you can debug it.