### PR TITLE
Fix: NaN values produce invalid json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Check gauges and counter values for NaN or Inf, before emitting them with the
+  telemetry sdk. There is an issue with the telemetry sdk were sending NaN
+  values produces an invalid json https://github.com/newrelic/go-telemetry-sdk/issues/2
+
 ## 1.2.2
 ### Added
 - Obfuscate the license key when logging the configuration. Running on debug

--- a/internal/integration/emitter.go
+++ b/internal/integration/emitter.go
@@ -190,17 +190,31 @@ func (te *TelemetryEmitter) Emit(metrics []Metric) error {
 	for _, metric := range metrics {
 		switch metric.metricType {
 		case metricType_GAUGE:
+			v, ok := metric.value.(float64)
+			if !ok {
+				continue
+			}
+			if !validNRValue(v) {
+				continue
+			}
 			te.harvester.RecordMetric(telemetry.Gauge{
 				Name:       metric.name,
 				Attributes: metric.attributes,
-				Value:      metric.value.(float64),
+				Value:      v,
 				Timestamp:  now,
 			})
 		case metricType_COUNTER:
+			v, ok := metric.value.(float64)
+			if !ok {
+				continue
+			}
+			if !validNRValue(v) {
+				continue
+			}
 			m, ok := te.deltaCalculator.CountMetric(
 				metric.name,
 				metric.attributes,
-				metric.value.(float64),
+				v,
 				now,
 			)
 			if ok {

--- a/internal/integration/emitter_test.go
+++ b/internal/integration/emitter_test.go
@@ -177,6 +177,28 @@ func TestTelemetryEmitterEmit(t *testing.T) {
 			value:      summary,
 			attributes: labels.Set{},
 		},
+		{
+			name:       "nan-gauge",
+			metricType: metricType_GAUGE,
+			value:      float64(math.NaN()),
+			attributes: labels.Set{
+				"name":           "nan-gauge",
+				"targetName":     "target-e",
+				"nrMetricType":   "gauge",
+				"promMetricType": "gauge",
+			},
+		},
+		{
+			name:       "nan-counter",
+			metricType: metricType_COUNTER,
+			value:      float64(math.NaN()),
+			attributes: labels.Set{
+				"name":           "nan-counter",
+				"targetName":     "target-f",
+				"nrMetricType":   "count",
+				"promMetricType": "counter",
+			},
+		},
 	}
 
 	var rawMetrics []interface{}


### PR DESCRIPTION
Some metrics which are NaN cause the sdk to produce an invalid json, the marshaling of the json doesn't fail and it's a problem in the telemetry sdk. I already open an issue in their repo.

https://github.com/newrelic/go-telemetry-sdk/issues/2

This invalid json was being sent to newrelic, and because it couldn't be parsed, the whole metrics batch was discarded. 

This PR checks the values for NaN or Inf before sending them to the sdk.