### PR TITLE
Don't run snyk on PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ go:
   - "1.13"
 script:
   - make
-  - npm install -g snyk
-  - make snyk
+  - 'if [ "$SNYK_TOKEN" != "" ]; then npm install -g snyk; fi'
+  - 'if [ "$SNYK_TOKEN" != "" ]; then make snyk; fi'
 services:
   - docker
 before_deploy:


### PR DESCRIPTION
Because of [this security constraint](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions), we can't execute the `snyk test` step on travis for pull requests.