### PR TITLE
Change delta calcaulator defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## NEXT RELEASE
+### Changed
+- Change the default for the New Relic telemetry emitter delta calculator 
+  expiration age and expiration check interval to 5 minutes. These values can 
+  now be configured with the following options
+  `telemetry_emitter_delta_expiration_age` and
+  `telemetry_emitter_delta_expiration_check_interval`. This solves the issue
+  with missing counters when the scrape interval takes more than the hard-coded
+  30 minutes values that we had previously.
+- Use go modules instead of govendor for managing project dependencies.
+
 ## 1.4.0
 ### Changed
 - Redact the password from URLs using simple authentication when storing target metadata.

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -89,6 +89,14 @@ data:
     # The HTTP client timeout when fetching data from endpoints. Defaults to 5s.
     # scrape_timeout: "5s"
 
+    # How old must the entries used for calculating the counters delta be
+    # before the telemetry emitter expires them. Defaults to 5m.
+    # telemetry_emitter_delta_expiration_age: "5m"
+
+    # How often must the telemetry emitter check for expired delta entries.
+    # Defaults to 5m.
+    # telemetry_emitter_delta_expiration_check_interval: "5m"
+
     # Wether the integration should run in verbose mode or not. Defaults to false.
     verbose: false
 

--- a/internal/integration/emitter.go
+++ b/internal/integration/emitter.go
@@ -21,9 +21,8 @@ import (
 )
 
 const (
-	// Ideally these 2 values should be configurable as integer multiples of the scrape interval.
-	defaultDeltaExpirationAge           = 30 * time.Second
-	defaultDeltaExpirationCheckInterval = 30 * time.Second
+	defaultDeltaExpirationAge           = 5 * time.Minute
+	defaultDeltaExpirationCheckInterval = 5 * time.Minute
 )
 
 // Emitter is an interface representing the ability to emit metrics.
@@ -147,24 +146,24 @@ func TelemetryHarvesterWithProxy(proxyURL *url.URL) TelemetryHarvesterOpt {
 func NewTelemetryEmitter(cfg TelemetryEmitterConfig) (*TelemetryEmitter, error) {
 	dc := cumulative.NewDeltaCalculator()
 
+	deltaExpirationAge := defaultDeltaExpirationAge
 	if cfg.DeltaExpirationAge != 0 {
-		dc.SetExpirationAge(cfg.DeltaExpirationAge)
-	} else {
-		dc.SetExpirationAge(defaultDeltaExpirationAge)
+		deltaExpirationAge = cfg.DeltaExpirationAge
 	}
+	dc.SetExpirationAge(deltaExpirationAge)
 	logrus.Debugf(
 		"telemetry emitter configured with delta counter expiration age: %s",
-		cfg.DeltaExpirationAge,
+		deltaExpirationAge,
 	)
 
+	deltaExpirationCheckInterval := defaultDeltaExpirationCheckInterval
 	if cfg.DeltaExpirationCheckInternval != 0 {
-		dc.SetExpirationCheckInterval(cfg.DeltaExpirationCheckInternval)
-	} else {
-		dc.SetExpirationCheckInterval(defaultDeltaExpirationCheckInterval)
+		deltaExpirationCheckInterval = cfg.DeltaExpirationCheckInternval
 	}
+	dc.SetExpirationCheckInterval(deltaExpirationCheckInterval)
 	logrus.Debugf(
 		"telemetry emitter configured with delta counter expiration check interval: %s",
-		cfg.DeltaExpirationAge,
+		deltaExpirationCheckInterval,
 	)
 
 	harvester, err := telemetry.NewHarvester(cfg.HarvesterOpts...)


### PR DESCRIPTION
Changes the values for the telemetry emitter delta calculator expiration
age and expiration check interval from 30 seconds to 5 minutes. Also
adds the following configuration options for setting each setting:

- telemetry_emitter_delta_expiration_age
- telemetry_emitter_delta_expiration_check_interval

This fixes the issue of missing datapoints for counters when the scrape
interval was taking longer than the delta expiration check interval and age.