### PR TITLE
Add pre-release support to release pipeline

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
       - linux
       - darwin
     hooks:
-      pre: env MAJOR_VERSION={{ .Major }}.{{ .Minor }} env MINOR_VERSION={{ .Major }}.{{ .Minor }}.{{ .Patch }} go generate ./...
+      pre: env MAJOR_MINOR_VERSION={{ .Major }}.{{ .Minor }} env PRE_RELEASE_VERSION={{ .Prerelease }} env FULL_VERSION={{ .Version }} go generate ./...
     ignore:
       - goarch: 386
 archives:
@@ -29,7 +29,12 @@ dockers:
       - nri-prometheus
     image_templates:
       - 'newrelic/nri-prometheus:{{ .Major }}.{{ .Minor }}'
-      - 'newrelic/nri-prometheus:{{ .Major }}.{{ .Minor }}.{{ .Patch }}'
+    skip_push: auto
+  - dockerfile: Dockerfile.release
+    binaries:
+      - nri-prometheus
+    image_templates:
+      - 'newrelic/nri-prometheus:{{ .Version }}'
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:

--- a/cmd/nri-prometheus/main.go
+++ b/cmd/nri-prometheus/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//go:generate go run -ldflags "-X main.majorVersion=$MAJOR_VERSION -X main.minorVersion=$MINOR_VERSION" ../../tools/deploy-yaml/main.go
+//go:generate go run -ldflags "-X main.majorMinorVersion=$MAJOR_MINOR_VERSION -X main.preReleaseVersion=$PRE_RELEASE_VERSION -X main.fullVersion=$FULL_VERSION" ../../tools/deploy-yaml/main.go
 func main() {
 	cfg, err := loadConfig()
 	if err != nil {

--- a/tools/deploy-yaml/main.go
+++ b/tools/deploy-yaml/main.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	majorVersion = "dev"
-	minorVersion = "dev"
+	majorMinorVersion = "dev"
+	preReleaseVersion = ""
+	fullVersion       = "dev"
 )
 
 func main() {
@@ -29,9 +30,13 @@ func main() {
 	if nil != err {
 		log.Fatal(err)
 	}
-	writeTemplate(tmpl, majorVersion, majorVersion)
-	writeTemplate(tmpl, minorVersion, minorVersion)
-	writeTemplate(tmpl, minorVersion, "latest")
+
+	writeTemplate(tmpl, fullVersion, fullVersion)
+	if preReleaseVersion != "" {
+		return
+	}
+	writeTemplate(tmpl, majorMinorVersion, majorMinorVersion)
+	writeTemplate(tmpl, fullVersion, "latest")
 }
 
 func writeTemplate(tmpl *template.Template, version string, yamlVersion string) {


### PR DESCRIPTION
Whenever there is a prerelease version `vX.Y.Z-rc` it will only upload the corresponding `vX.Y.Z-rc` yaml and docker tag