### PR TITLE
feat(config): added config option to enable/disable autodiscovery

### DIFF
--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -76,7 +76,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("auto_decorate", false)
 	viper.SetDefault("insecure_skip_verify", false)
 	viper.SetDefault("standalone", true)
-	viper.SetDefault("enable_autodiscovery", true)
+	viper.SetDefault("disable_autodiscovery", false)
 	viper.SetDefault("percentiles", []float64{50.0, 95.0, 99.0})
 }
 

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -76,6 +76,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("auto_decorate", false)
 	viper.SetDefault("insecure_skip_verify", false)
 	viper.SetDefault("standalone", true)
+	viper.SetDefault("enable_autodiscovery", true)
 	viper.SetDefault("percentiles", []float64{50.0, 95.0, 99.0})
 }
 

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -93,6 +93,9 @@ data:
     insecure_skip_verify: false
     # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
     scrape_enabled_label: "prometheus.io/scrape"
+    # Set to false in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
+    # having limited privileges
+    # enable_autodiscovery: true
     # Wether k8s nodes needs to be labelled to be scraped or not. Defaults to false.
     require_scrape_enabled_label_for_nodes: true
     #targets:

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -93,9 +93,9 @@ data:
     insecure_skip_verify: false
     # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
     scrape_enabled_label: "prometheus.io/scrape"
-    # Set to false in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
-    # having limited privileges
-    # enable_autodiscovery: true
+    # Set to true in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
+    # having limited privileges. Defaults to false.
+    # disable_autodiscovery: false
     # Wether k8s nodes needs to be labelled to be scraped or not. Defaults to false.
     require_scrape_enabled_label_for_nodes: true
     #targets:

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -132,6 +132,10 @@ data:
     # If left empty, TLS uses the host's root CA set.
     # emitter_ca_file: "/path/to/cert/server.pem"
 
+    # Set to false in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
+    # having limited privileges
+    # enable_autodiscovery: true
+
     # Whether the emitter should skip TLS verification when submitting data.
     # Defaults to false.
     # emitter_insecure_skip_verify: false

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -132,9 +132,9 @@ data:
     # If left empty, TLS uses the host's root CA set.
     # emitter_ca_file: "/path/to/cert/server.pem"
 
-    # Set to false in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
-    # having limited privileges
-    # enable_autodiscovery: true
+    # Set to true in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
+    # having limited privileges. Defaults to false.
+    # disable_autodiscovery: false
 
     # Whether the emitter should skip TLS verification when submitting data.
     # Defaults to false.

--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -33,7 +33,7 @@ type Config struct {
 	RequireScrapeEnabledLabelForNodes bool                         `mapstructure:"require_scrape_enabled_label_for_nodes"`
 	ScrapeTimeout                     time.Duration                `mapstructure:"scrape_timeout"`
 	Standalone                        bool                         `mapstructure:"standalone"`
-	EnableAutodiscovery               bool                         `mapstructure:"enable_autodiscovery"`
+	DisableAutodiscovery              bool                         `mapstructure:"disable_autodiscovery"`
 	ScrapeDuration                    string                       `mapstructure:"scrape_duration"`
 	EmitterHarvestPeriod              string                       `mapstructure:"emitter_harvest_period"`
 	TargetConfigs                     []endpoints.TargetConfig     `mapstructure:"targets"`
@@ -120,7 +120,7 @@ func RunWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 	}
 	retrievers = append(retrievers, fixedRetriever)
 
-	if cfg.EnableAutodiscovery {
+	if !cfg.DisableAutodiscovery {
 		kubernetesRetriever, err := endpoints.NewKubernetesTargetRetriever(cfg.ScrapeEnabledLabel, cfg.RequireScrapeEnabledLabelForNodes, endpoints.WithInClusterConfig())
 		if err != nil {
 			logrus.WithError(err).Errorf("not possible to get a Kubernetes client. If you aren't running this integration in a Kubernetes cluster, you can ignore this error")


### PR DESCRIPTION
**Use Case**
Sometimes we want to run the integration in an environment where autodiscovery is not needed or due to permission limitation cannot be performed. In this scenarios hundreds of error logs were shown together with failing request to k8s APIs.


Es: service account running the pod ha not visibility into the whole cluster.
```
time="2020-08-28T11:20:53Z" level=warning msg="couldn't list node resource, retrying" component=KubernetesAPI error="timeout reached, 60 retries executed. last error: nodes is forbidden: User \"system:serviceaccount:new-relic:nri-prometheus\" cannot list resource \"nodes\" in API group \"\" at the cluster scope"
```

**Solution**
 - A config option `enable_autodiscovery ` has been added in order to add the possibility to enable/disable autodiscovery.
 - By default such config is set to `true`

UPDATE

After discussion the config option as been called `disable_autodiscovery` with default `false`