### PR TITLE
fix(k8sManifest): configfile added as alias of config_path

### DIFF
--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -19,6 +19,7 @@ import (
 // ArgumentList Available Arguments
 type ArgumentList struct {
 	ConfigPath string `default:"" help:"Path to the config file"`
+	Configfile string `default:"" help:"Deprecated. --config_path takes precedence if both are set"`
 }
 
 func loadConfig() (*scraper.Config, error) {
@@ -31,6 +32,10 @@ func loadConfig() (*scraper.Config, error) {
 
 	cfg := viper.New()
 	cfg.SetConfigType("yaml")
+
+	if c.Configfile != "" && c.ConfigPath == "" {
+		c.ConfigPath = c.Configfile
+	}
 
 	if c.ConfigPath != "" {
 		cfg.AddConfigPath(filepath.Dir(c.ConfigPath))

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -58,7 +58,7 @@ spec:
       - name: nri-prometheus
         image: quay.io/newrelic/nri-prometheus
         args:
-          - "--configfile=/etc/nri-prometheus/config.yaml"
+          - "--config_path=/etc/nri-prometheus/config.yaml"
         ports:
           - containerPort: 8080
         volumeMounts:

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -59,7 +59,7 @@ spec:
       - name: nri-prometheus
         image: newrelic/nri-prometheus:{{ .Version }}
         args:
-          - "--configfile=/etc/nri-prometheus/config.yaml"
+          - "--config_path=/etc/nri-prometheus/config.yaml"
         ports:
           - containerPort: 8080
         volumeMounts:

--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -22,7 +22,6 @@ import (
 
 // Config is the config struct for the scraper.
 type Config struct {
-	ConfigFile                        string
 	MetricAPIURL                      string                       `mapstructure:"metric_api_url"`
 	LicenseKey                        LicenseKey                   `mapstructure:"license_key"`
 	ClusterName                       string                       `mapstructure:"cluster_name"`


### PR DESCRIPTION
**Reason behind the change**

In the k8s manifests I noticed that the `--configfile ` argument was passed. However, such argument was ignored since the config file path was hardcoded.

After we moved to the infraSDK if an unexpected argument is passed an error is returned. Therefore after updating the manifest with the correct argument I added the old argument as an alias.

Be aware that we decided to change the config name since the agent pass the environment variable `CONFIG_PATH`
