### PR TITLE
Ignored Nan and Infinite float values

### DIFF
--- a/internal/integration/emitter_test.go
+++ b/internal/integration/emitter_test.go
@@ -179,6 +179,12 @@ func TestTelemetryEmitterEmit(t *testing.T) {
 			value:      summary,
 			attributes: labels.Set{},
 		},
+		{
+			name:       "not a number, NAN",
+			metricType: metricType_COUNTER,
+			value:      math.NaN(),
+			attributes: labels.Set{},
+		},
 	}
 
 	var rawMetrics []interface{}

--- a/internal/integration/harvester_decorator.go
+++ b/internal/integration/harvester_decorator.go
@@ -32,14 +32,15 @@ func (ha harvesterDecorator) HarvestNow(ctx context.Context) {
 }
 
 func (ha harvesterDecorator) processMetric(f float64, m telemetry.Metric) {
-	if isNaNOrInfinity(f) {
+	if math.IsNaN(f) {
 		logrus.Debugf("Ignoring NaN float value for metric: %v", m)
 		return
 	}
 
-	ha.innerHarvester.RecordMetric(m)
-}
+	if math.IsInf(f, 0) {
+		logrus.Debugf("Ignoring Infinite float value for metric: %v", m)
+		return
+	}
 
-func isNaNOrInfinity(f float64) bool {
-	return math.IsInf(f, 0) || math.IsNaN(f)
+	ha.innerHarvester.RecordMetric(m)
 }

--- a/internal/integration/harvester_decorator.go
+++ b/internal/integration/harvester_decorator.go
@@ -1,0 +1,45 @@
+package integration
+
+import (
+	"context"
+	"math"
+
+	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"github.com/sirupsen/logrus"
+)
+
+// harvesterDecorator is a layer on top of another harvester that filters out NaN and Infinite float values.
+type harvesterDecorator struct {
+	innerHarvester harvester
+}
+
+func (ha harvesterDecorator) RecordMetric(m telemetry.Metric) {
+	switch a := m.(type) {
+	case telemetry.Count:
+		ha.processMetric(a.Value, m)
+	case telemetry.Summary:
+		ha.processMetric(a.Sum, m)
+	case telemetry.Gauge:
+		ha.processMetric(a.Value, m)
+	default:
+		logrus.Debugf("Unexpected metric in harvesterDecorator: #%v", m)
+		ha.innerHarvester.RecordMetric(m)
+	}
+}
+
+func (ha harvesterDecorator) HarvestNow(ctx context.Context) {
+	ha.innerHarvester.HarvestNow(ctx)
+}
+
+func (ha harvesterDecorator) processMetric(f float64, m telemetry.Metric) {
+	if isNaNOrInfinity(f) {
+		logrus.Debugf("Ignoring NaN float value for metric: %v", m)
+		return
+	}
+
+	ha.innerHarvester.RecordMetric(m)
+}
+
+func isNaNOrInfinity(f float64) bool {
+	return math.IsInf(f, 0) || math.IsNaN(f)
+}


### PR DESCRIPTION
These values cannot be handled by NRDB, and POMI currently logs an error message for every single NaN/Infinite value it processes, which can be confusing.