### PR TITLE
fix: use personal token for helm bumper

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -10,10 +10,10 @@ jobs:
     - name: Create PR using Version Bump 
       run: |
         appVersion=${{github.event.release.tag_name}}
-        chartName=${{github.repository}}
+        chartName=nri-prometheus
         
         curl -H "Accept: application/vnd.github.everest-preview+json" \
-        -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+        -H "Authorization: token ${{ secrets.VERSION_BUMP_TOKEN }}" \
         --request POST \
         --data '{"event_type": "bump-chart-version", "client_payload": { "chart_name": "${chartName}", "chart_version": "", "app_version": "${appVersion:1}"}}' \
         https://api.github.com/repos/newrelic/helm-charts/dispatches

--- a/Makefile
+++ b/Makefile
@@ -98,20 +98,9 @@ release: release/deps
 	@echo "=== $(INTEGRATION) === [ release ]: Releasing new version..."
 	@$(GORELEASER_BIN) release
 	@(aws s3 sync ./target/deploy/ ${S3_BUCKET})
-	@$(MAKE) snyk/monitor
 
 release/test: release/deps
 	@echo "=== $(INTEGRATION) === [ release/test ]: Testing releasing new version..."
 	@$(GORELEASER_BIN) release --snapshot --skip-publish --rm-dist
 
-snyk: deps-only
-	@echo "=== $(INTEGRATION) === [ snyk ]: Running snyk..."
-	# @snyk test # issue with Govendor causing snyk to fail
-	@snyk test --docker $(IMAGE_NAME):release --file=Dockerfile.release
-
-snyk/monitor: deps-only
-	@echo "=== $(INTEGRATION) === [ snyk/monitor ]: Running snyk..."
-	# @snyk monitor # issue with Govendor causing snyk to fail
-	@snyk monitor --docker $(IMAGE_NAME):release --file=Dockerfile.release
-
-.PHONY: all build clean tools tools-update deps deps-only validate compile compile-only test check-version tools-golangci-lint docker-build release release/deps release/test snyk snyk/monitor docker-release
+.PHONY: all build clean tools tools-update deps deps-only validate compile compile-only test check-version tools-golangci-lint docker-build release release/deps release/test docker-release


### PR DESCRIPTION
Uses PAT as secret for execute the helm chart version bumper since secrets.GITHUB_TOKEN is not allowed 

Removes snyk step from Make , since is already executing in GHA