### PR TITLE
fix: default configs emitter and definition path

### DIFF
--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -296,7 +296,7 @@ func Run(cfg *Config) error {
 		case "infra-sdk":
 			specs, err := integration.LoadSpecFiles(cfg.DefinitionFilesPath)
 			if err != nil {
-				return err
+				logrus.Errorf("error loading definition files: %s", err)
 			}
 			emitter := integration.NewInfraSdkEmitter(specs)
 			emitters = append(emitters, emitter)

--- a/internal/integration/infra_sdk_emitter.go
+++ b/internal/integration/infra_sdk_emitter.go
@@ -59,6 +59,8 @@ func (e *InfraSdkEmitter) Emit(metrics []Metric) error {
 			logrus.WithError(err).Errorf("failed to create metric from '%s'", me.name)
 		}
 	}
+	logrus.Debugf("%d metrics processed", len(metrics))
+	logrus.Debugf("%d metrics not found in definition file and added to the Host Entity", len(i.HostEntity.Metrics))
 
 	return i.Publish()
 }
@@ -127,7 +129,6 @@ func (e *InfraSdkEmitter) addMetricToEntity(i *sdk.Integration, metric Metric, m
 	entityProps, err := e.definitions.getEntity(metric)
 	// if we can't find an entity for the metric, add it to the "host" entity
 	if err != nil {
-		logrus.WithError(err).Debugf("failed to map metric to entity. using 'host' entity")
 		i.HostEntity.AddMetric(m)
 		return nil
 	}


### PR DESCRIPTION
Adds default value for:
* DefinitionFilesPath
* Emitter: uses `infra-sdk` when standalone is false and `telemetry` when is true (backward compatibility)

This PR fixes issue #83 