### PR TITLE
fix(entityName): ensuring ordering of labels

### DIFF
--- a/internal/integration/infra_sdk_emitter.go
+++ b/internal/integration/infra_sdk_emitter.go
@@ -174,7 +174,7 @@ func buildEntityName(props entityNameProps, m infra.Metric) string {
 
 	for _, v := range props.Labels {
 		sb.WriteRune(':')
-		sb.WriteString(v)
+		sb.WriteString(v.Value)
 	}
 
 	original := sb.String()

--- a/internal/integration/spec.go
+++ b/internal/integration/spec.go
@@ -54,7 +54,12 @@ type entityNameProps struct {
 	DisplayName string
 	Type        string
 	Service     string
-	Labels      map[string]string
+	Labels      []keyValue
+}
+
+type keyValue struct {
+	Key   string
+	Value string
 }
 
 // LoadSpecFiles loads all service spec files named like "prometheus_*.yml" that are in the filesPath
@@ -124,7 +129,7 @@ func (s *Specs) getEntity(m Metric) (props entityNameProps, err error) {
 	props.DisplayName = e.DisplayName
 	props.Type = strings.Title(spec.Service) + strings.Title(e.Name)
 	props.Service = spec.Service
-	props.Labels = map[string]string{}
+	props.Labels = []keyValue{}
 
 	for _, d := range e.Properties.Labels {
 		var val interface{}
@@ -133,7 +138,7 @@ func (s *Specs) getEntity(m Metric) (props entityNameProps, err error) {
 		if val, ok = m.attributes[d]; !ok {
 			return entityNameProps{}, fmt.Errorf("label %s not found in metric %s", d, m.name)
 		}
-		props.Labels[d] = fmt.Sprintf("%v", val)
+		props.Labels = append(props.Labels, keyValue{fmt.Sprintf("%v", d), fmt.Sprintf("%v", val)})
 	}
 
 	return props, nil

--- a/internal/integration/spec_test.go
+++ b/internal/integration/spec_test.go
@@ -51,7 +51,7 @@ func TestSpecs_getEntity(t *testing.T) {
 					},
 				}},
 			wantProps: entityNameProps{Service: "ravendb", Name: "database", DisplayName: "Database", Type: "RavendbDatabase",
-				Labels: map[string]string{"database": "test"}},
+				Labels: []keyValue{{"database", "test"}}},
 			wantErr: false,
 		},
 		{
@@ -62,7 +62,7 @@ func TestSpecs_getEntity(t *testing.T) {
 					name:       "ravendb_document_put_bytes_total",
 					attributes: labels.Set{},
 				}},
-			wantProps: entityNameProps{Service: "ravendb", Name: "node", DisplayName: "RavenDb Node", Type: "RavendbNode", Labels: map[string]string{}},
+			wantProps: entityNameProps{Service: "ravendb", Name: "node", DisplayName: "RavenDb Node", Type: "RavendbNode", Labels: []keyValue{}},
 			wantErr:   false,
 		},
 		{
@@ -77,7 +77,7 @@ func TestSpecs_getEntity(t *testing.T) {
 					},
 				}},
 			wantProps: entityNameProps{Service: "ravendb", Name: "testentity", DisplayName: "testEntity", Type: "RavendbTestentity",
-				Labels: map[string]string{"dim1": "first", "dim2": "second"}},
+				Labels: []keyValue{{"dim1", "first"}, {"dim2", "second"}}},
 			wantErr: false,
 		},
 		{
@@ -89,7 +89,7 @@ func TestSpecs_getEntity(t *testing.T) {
 					attributes: labels.Set{},
 				}},
 			wantProps: entityNameProps{Service: "redis", Name: "instance", DisplayName: "Redis Instance", Type: "RedisInstance",
-				Labels: map[string]string{}},
+				Labels: []keyValue{}},
 			wantErr: false,
 		},
 		{
@@ -101,7 +101,7 @@ func TestSpecs_getEntity(t *testing.T) {
 					attributes: labels.Set{},
 				}},
 			wantProps: entityNameProps{Service: "redis", Name: "instance", DisplayName: "Redis Instance", Type: "RedisInstance",
-				Labels: map[string]string{}},
+				Labels: []keyValue{}},
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
Moving from a Map to a slice of keyvalues to ensure ordering.

There were different ways assure the same, but I followed this approach to keep the logic as similar as possible to the initial one

The bug was causing entities to change the name due to label ordering:
```
github:10.0.2.2:9999:job:289885995:MDExOldvcmtmbG93UnVuMjg5ODg1OTk1
github:10.0.2.2:9999:job:MDExOldvcmtmbG93UnVuMjg5ODg1OTk1:289885995
```