### PR TITLE
Improve CA support configuration for HTTPS scrapping

### DIFF
--- a/internal/integration/fetcher.go
+++ b/internal/integration/fetcher.go
@@ -43,7 +43,10 @@ func NewTLSConfig(CAFile string, InsecureSkipVerify bool) (*tls.Config, error) {
 	tlsConfig := &tls.Config{InsecureSkipVerify: InsecureSkipVerify}
 
 	if len(CAFile) > 0 {
-		caCertPool := x509.NewCertPool()
+		caCertPool, err := x509.SystemCertPool()
+		if err != nil {
+			caCertPool = x509.NewCertPool()
+		}
 		caCert, err := ioutil.ReadFile(CAFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to use specified CA cert %s: %s", CAFile, err)


### PR DESCRIPTION
When configuring `CA_FILE` (like in case of Kubernetes setup) it is not possible to scrape TLS/HTTPS endpoints because there is only once valid certificate. This change is using standard default CA certificates and adds provided CA certificate to the pool. Standard certificates can still be configured by using `SSL_CERT_FILE` and `SSL_CERT_DIR`.