### PR TITLE
feat: accept duplicated service definitions

### DIFF
--- a/internal/integration/spec.go
+++ b/internal/integration/spec.go
@@ -91,7 +91,14 @@ func LoadSpecFiles(filesPath string) (Specs, error) {
 			continue
 		}
 		logrus.Debugf("spec file loaded for service:%s", sd.Service)
-		specs.SpecsByName[sd.Service] = sd
+		if spec, ok := specs.SpecsByName[sd.Service]; ok {
+			spec.Entities = append(spec.Entities, sd.Entities...)
+			specs.SpecsByName[sd.Service] = spec
+			//TODO how to manage defaultEntity for each spec?
+		} else {
+			specs.SpecsByName[sd.Service] = sd
+		}
+
 	}
 
 	return specs, nil

--- a/internal/integration/spec_test.go
+++ b/internal/integration/spec_test.go
@@ -105,6 +105,18 @@ func TestSpecs_getEntity(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:   "redisBisMetric",
+			fields: fields{specs.SpecsByName},
+			args: args{
+				Metric{
+					name:       "redis_metric_bis",
+					attributes: labels.Set{},
+				}},
+			wantProps: entityNameProps{Service: "redis", Name: "testbisredis", DisplayName: "Redis test bis", Type: "REDIS_TESTBISREDIS",
+				Labels: []keyValue{}},
+			wantErr: false,
+		},
+		{
 			name:    "missingDimentions",
 			fields:  fields{specs.SpecsByName},
 			args:    args{Metric{name: "ravendb_database_document_put_bytes_total"}},

--- a/internal/integration/test/prometheus_redis_bis.yml
+++ b/internal/integration/test/prometheus_redis_bis.yml
@@ -1,0 +1,10 @@
+service: redis
+display_name: Redis
+entities:
+  - name: testbisredis
+    display_name: Redis test bis
+    metrics:
+      - provider_name: redis_metric_bis
+        description: Total amount of time in seconds spent per command 
+        unit: Counter
+


### PR DESCRIPTION
This PR allows two exporter with same metric namespace to have different definition files . 

This approach just adds the entities from all definitions files that share the same service name to the same object. 

In the future the entity discovery mechanism should be replaced and this approach will no longer be needed. 