### PR TITLE
fix: update sdk fixes count type metrics agent error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/googleapis/gnostic v0.2.3-0.20181019180348-e2aafd60c944 // indirect
 	github.com/hashicorp/hcl v1.0.1-0.20190611123218-cf7d376da96d // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
-	github.com/newrelic/infra-integrations-sdk v1.0.1-0.20200907091437-3448c6399fd2
+	github.com/newrelic/infra-integrations-sdk v1.0.1-0.20201016141521-6fdfe28ad6c0
 	github.com/newrelic/newrelic-telemetry-sdk-go v0.4.0
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/newrelic/infra-integrations-sdk v1.0.1-0.20200907091437-3448c6399fd2 h1:I/SM8ymHVdbDpDuOIf3Km/+YVw3P9MeOjkwH1KrVHCk=
-github.com/newrelic/infra-integrations-sdk v1.0.1-0.20200907091437-3448c6399fd2/go.mod h1:pkt52iL985phO3d+kREkalNFJdjYyccUDTD+IK/Pno8=
+github.com/newrelic/infra-integrations-sdk v1.0.1-0.20201016141521-6fdfe28ad6c0 h1:E+vVSdCOVKDryTQNKrsHxAh4GeeCWPfZWZ7vMDRbvlo=
+github.com/newrelic/infra-integrations-sdk v1.0.1-0.20201016141521-6fdfe28ad6c0/go.mod h1:pkt52iL985phO3d+kREkalNFJdjYyccUDTD+IK/Pno8=
 github.com/newrelic/newrelic-telemetry-sdk-go v0.4.0 h1:x9e37QJxmEX1659zmaeOh9dlUKQTmWHIJVRsFTtfDL4=
 github.com/newrelic/newrelic-telemetry-sdk-go v0.4.0/go.mod h1:G9MqE/cHGv3Hx3qpYhfuyFUsGx2DpVcGi1iJIqTg+JQ=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=


### PR DESCRIPTION
this updates the infra sdk module that contain a fix for `counter` type metrics. 