### PR TITLE
Add audit-logging setting

### DIFF
--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -95,6 +95,7 @@ func loadConfig() (*scraper.Config, error) {
 func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("debug", false)
 	viper.SetDefault("verbose", false)
+	viper.SetDefault("audit", false)
 	viper.SetDefault("scrape_enabled_label", "prometheus.io/scrape")
 	viper.SetDefault("require_scrape_enabled_label_for_nodes", true)
 	viper.SetDefault("scrape_timeout", 5*time.Second)

--- a/configs/nri-prometheus-config.yml.sample
+++ b/configs/nri-prometheus-config.yml.sample
@@ -4,7 +4,7 @@ integrations:
       # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data. Defaults to true
       standalone: false
 
-      # When running with infrastructure agent emitters will have to include infra-sdk  
+      # When running with infrastructure agent emitters will have to include infra-sdk
       emitters: infra-sdk
 
       # The name of your cluster. It's important to match other New Relic products to relate the data.
@@ -20,6 +20,11 @@ integrations:
 
       # Whether the integration should run in verbose mode or not. Defaults to false.
       verbose: false
+
+      # Whether the integration should run in audit mode or not. Defaults to false.
+      # Audit mode logs the uncompressed data sent to New Relic. Use this to log all data sent.
+      # It does not include verbose mode. This can lead to a high log volume, use with care.
+      audit: false
 
       # The HTTP client timeout when fetching data from endpoints. Defaults to 30s.
       # scrape_timeout: "30s"

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -89,6 +89,10 @@ data:
     # scrape_timeout: "30s"
     # Wether the integration should run in verbose mode or not. Defaults to false.
     verbose: false
+    # Whether the integration should run in audit mode or not. Defaults to false.
+    # Audit mode logs the uncompressed data sent to New Relic. Use this to log all data sent.
+    # It does not include verbose mode. This can lead to a high log volume, use with care.
+    audit: false
     # Wether the integration should skip TLS verification or not. Defaults to false.
     insecure_skip_verify: false
     # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -103,6 +103,11 @@ data:
     # Wether the integration should run in verbose mode or not. Defaults to false.
     verbose: false
 
+    # Whether the integration should run in audit mode or not. Defaults to false.
+    # Audit mode logs the uncompressed data sent to New Relic. Use this to log all data sent.
+    # It does not include verbose mode. This can lead to a high log volume, use with care.
+    audit: false
+
     # Wether the integration should skip TLS verification or not. Defaults to false.
     insecure_skip_verify: false
 

--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -27,6 +27,7 @@ type Config struct {
 	ClusterName                       string                       `mapstructure:"cluster_name"`
 	Debug                             bool                         `mapstructure:"debug"`
 	Verbose                           bool                         `mapstructure:"verbose"`
+	Audit                             bool                         `mapstructure:"audit"`
 	Emitters                          []string                     `mapstructure:"emitters"`
 	ScrapeEnabledLabel                string                       `mapstructure:"scrape_enabled_label"`
 	RequireScrapeEnabledLabelForNodes bool                         `mapstructure:"require_scrape_enabled_label_for_nodes"`
@@ -283,6 +284,10 @@ func Run(cfg *Config) error {
 
 			if cfg.Verbose {
 				harvesterOpts = append(harvesterOpts, telemetry.ConfigBasicDebugLogger(os.Stdout))
+			}
+
+			if cfg.Audit {
+				harvesterOpts = append(harvesterOpts, telemetry.ConfigBasicAuditLogger(os.Stdout))
 			}
 
 			c := integration.TelemetryEmitterConfig{


### PR DESCRIPTION
This adds a config option to enable audit logging in the telemetry emitter. Sometimes this is useful to debug metric issues.