### PR TITLE
fix(promMetrics): resetting metrics to avoid leakage

### DIFF
--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/nri-prometheus/internal/pkg/endpoints"
+	nrprom "github.com/newrelic/nri-prometheus/internal/pkg/prometheus"
 )
 
 const (
@@ -50,6 +51,10 @@ func Execute(
 		totalTimeseriesByTargetMetric.Reset()
 		totalTimeseriesByTargetAndTypeMetric.Reset()
 		totalTimeseriesByTypeMetric.Reset()
+		fetchTargetDurationMetric.Reset()
+		fetchesTotalMetric.Reset()
+		fetchErrorsTotalMetric.Reset()
+		nrprom.ResetTargetSize()
 
 		startTime := time.Now()
 		process(retrievers, fetcher, processor, emitters)

--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -43,7 +43,7 @@ func ResetTotalScrapedPayload() {
 	totalScrapedPayload.Set(0)
 }
 
-// v resets the integration targetSize
+// ResetTargetSize resets the integration targetSize
 // metric.
 func ResetTargetSize() {
 	targetSize.Reset()
@@ -86,6 +86,5 @@ func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 	bodySize := float64(countedBody.count)
 	targetSize.With(prom.Labels{"target": url}).Set(bodySize)
 	totalScrapedPayload.Add(bodySize)
-
 	return mfs, nil
 }

--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -43,6 +43,12 @@ func ResetTotalScrapedPayload() {
 	totalScrapedPayload.Set(0)
 }
 
+// v resets the integration targetSize
+// metric.
+func ResetTargetSize() {
+	targetSize.Reset()
+}
+
 // Get scrapes the given URL and decodes the retrieved payload.
 func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 	mfs := MetricFamiliesByName{}
@@ -80,5 +86,6 @@ func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 	bodySize := float64(countedBody.count)
 	targetSize.With(prom.Labels{"target": url}).Set(bodySize)
 	totalScrapedPayload.Add(bodySize)
+
 	return mfs, nil
 }


### PR DESCRIPTION
The metrics were not resetted properly and this was causing a possible leakage of them.

#### New Behaviour
Before deleting kube-state-metric
```
# HELP nr_stats_discoveries_total Attempted discoveries
# TYPE nr_stats_discoveries_total gauge
nr_stats_discoveries_total{retriever="fixed"} 1
nr_stats_discoveries_total{retriever="kubernetes"} 1
# HELP nr_stats_fetches_total Fetches attempted
# TYPE nr_stats_fetches_total gauge
nr_stats_fetches_total{target="demo.robustperception.io:9100"} 1
nr_stats_fetches_total{target="kube-dns"} 1
nr_stats_fetches_total{target="test-kube-state-metrics"} 1
# HELP nr_stats_integration_emit_total_duration_seconds The total time in seconds to emit all the metrics
# TYPE nr_stats_integration_emit_total_duration_seconds gauge
nr_stats_integration_emit_total_duration_seconds{emitter="telemetry"} 20.027329149
# HELP nr_stats_integration_fetch_target_duration_seconds The total time in seconds to fetch the metrics of a target
# TYPE nr_stats_integration_fetch_target_duration_seconds gauge
nr_stats_integration_fetch_target_duration_seconds{target="demo.robustperception.io:9100"} 0.123778485
nr_stats_integration_fetch_target_duration_seconds{target="kube-dns"} 0.003789195
nr_stats_integration_fetch_target_duration_seconds{target="test-kube-state-metrics"} 0.013140416
# HELP nr_stats_integration_list_targets_duration_by_kind The total time in seconds to get the list of targets for a resource kind
# TYPE nr_stats_integration_list_targets_duration_by_kind gauge
nr_stats_integration_list_targets_duration_by_kind{kind="node",retriever="kubernetes"} 0.014786913
nr_stats_integration_list_targets_duration_by_kind{kind="pod",retriever="kubernetes"} 0.018253595
nr_stats_integration_list_targets_duration_by_kind{kind="service",retriever="kubernetes"} 0.012384405
# HELP nr_stats_integration_payload_size Size of target's payload
# TYPE nr_stats_integration_payload_size gauge
nr_stats_integration_payload_size{target="http://demo.robustperception.io:9100/metrics"} 49523
nr_stats_integration_payload_size{target="http://kube-dns.kube-system.svc:9153/metrics"} 17426
nr_stats_integration_payload_size{target="http://test-kube-state-metrics.new-relic.svc:8080/metrics"} 250495
# HELP nr_stats_integration_process_duration_seconds The total time in seconds to process all the steps of the integration
# TYPE nr_stats_integration_process_duration_seconds gauge
nr_stats_integration_process_duration_seconds 20.027500715
# HELP nr_stats_integration_total_payload_size Total size of the payloads scraped
# TYPE nr_stats_integration_total_payload_size gauge
nr_stats_integration_total_payload_size 317444
# HELP nr_stats_metrics_total_timeseries Total number of timeseries
# TYPE nr_stats_metrics_total_timeseries gauge
nr_stats_metrics_total_timeseries 2233
# HELP nr_stats_metrics_total_timeseries_by_target Total number of timeseries by target
# TYPE nr_stats_metrics_total_timeseries_by_target gauge
nr_stats_metrics_total_timeseries_by_target{target="demo.robustperception.io:9100"} 412
nr_stats_metrics_total_timeseries_by_target{target="kube-dns"} 66
nr_stats_metrics_total_timeseries_by_target{target="test-kube-state-metrics"} 1755
# HELP nr_stats_metrics_total_timeseries_by_target_type Total number of metrics by type and target
# TYPE nr_stats_metrics_total_timeseries_by_target_type gauge
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="counter"} 93
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="gauge"} 274
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="summary"} 1
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="untyped"} 44
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="counter"} 21
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="gauge"} 39
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="histogram"} 5
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="summary"} 1
nr_stats_metrics_total_timeseries_by_target_type{target="test-kube-state-metrics",type="counter"} 21
nr_stats_metrics_total_timeseries_by_target_type{target="test-kube-state-metrics",type="gauge"} 1734
# HELP nr_stats_metrics_total_timeseries_by_type Total number of metrics by type
# TYPE nr_stats_metrics_total_timeseries_by_type gauge
nr_stats_metrics_total_timeseries_by_type{type="counter"} 135
nr_stats_metrics_total_timeseries_by_type{type="gauge"} 2047
nr_stats_metrics_total_timeseries_by_type{type="histogram"} 5
nr_stats_metrics_total_timeseries_by_type{type="summary"} 2
nr_stats_metrics_total_timeseries_by_type{type="untyped"} 44
# HELP nr_stats_targets Discovered targets
# TYPE nr_stats_targets gauge
nr_stats_targets{retriever="fixed"} 1
nr_stats_targets{retriever="kubernetes"} 2
```

After deleting
```
# HELP nr_stats_discoveries_total Attempted discoveries
# TYPE nr_stats_discoveries_total gauge
nr_stats_discoveries_total{retriever="fixed"} 1
nr_stats_discoveries_total{retriever="kubernetes"} 1
# HELP nr_stats_fetches_total Fetches attempted
# TYPE nr_stats_fetches_total gauge
nr_stats_fetches_total{target="demo.robustperception.io:9100"} 1
nr_stats_fetches_total{target="kube-dns"} 1
# HELP nr_stats_integration_emit_total_duration_seconds The total time in seconds to emit all the metrics
# TYPE nr_stats_integration_emit_total_duration_seconds gauge
nr_stats_integration_emit_total_duration_seconds{emitter="telemetry"} 15.005048695
# HELP nr_stats_integration_fetch_target_duration_seconds The total time in seconds to fetch the metrics of a target
# TYPE nr_stats_integration_fetch_target_duration_seconds gauge
nr_stats_integration_fetch_target_duration_seconds{target="demo.robustperception.io:9100"} 0.131236605
nr_stats_integration_fetch_target_duration_seconds{target="kube-dns"} 0.003312731
# HELP nr_stats_integration_list_targets_duration_by_kind The total time in seconds to get the list of targets for a resource kind
# TYPE nr_stats_integration_list_targets_duration_by_kind gauge
nr_stats_integration_list_targets_duration_by_kind{kind="node",retriever="kubernetes"} 0.014786913
nr_stats_integration_list_targets_duration_by_kind{kind="pod",retriever="kubernetes"} 0.018253595
nr_stats_integration_list_targets_duration_by_kind{kind="service",retriever="kubernetes"} 0.012384405
# HELP nr_stats_integration_payload_size Size of target's payload
# TYPE nr_stats_integration_payload_size gauge
nr_stats_integration_payload_size{target="http://demo.robustperception.io:9100/metrics"} 49540
nr_stats_integration_payload_size{target="http://kube-dns.kube-system.svc:9153/metrics"} 17433
# HELP nr_stats_integration_process_duration_seconds The total time in seconds to process all the steps of the integration
# TYPE nr_stats_integration_process_duration_seconds gauge
nr_stats_integration_process_duration_seconds 15.005071312
# HELP nr_stats_integration_total_payload_size Total size of the payloads scraped
# TYPE nr_stats_integration_total_payload_size gauge
nr_stats_integration_total_payload_size 66973
# HELP nr_stats_metrics_total_timeseries Total number of timeseries
# TYPE nr_stats_metrics_total_timeseries gauge
nr_stats_metrics_total_timeseries 478
# HELP nr_stats_metrics_total_timeseries_by_target Total number of timeseries by target
# TYPE nr_stats_metrics_total_timeseries_by_target gauge
nr_stats_metrics_total_timeseries_by_target{target="demo.robustperception.io:9100"} 412
nr_stats_metrics_total_timeseries_by_target{target="kube-dns"} 66
# HELP nr_stats_metrics_total_timeseries_by_target_type Total number of metrics by type and target
# TYPE nr_stats_metrics_total_timeseries_by_target_type gauge
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="counter"} 93
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="gauge"} 274
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="summary"} 1
nr_stats_metrics_total_timeseries_by_target_type{target="demo.robustperception.io:9100",type="untyped"} 44
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="counter"} 21
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="gauge"} 39
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="histogram"} 5
nr_stats_metrics_total_timeseries_by_target_type{target="kube-dns",type="summary"} 1
# HELP nr_stats_metrics_total_timeseries_by_type Total number of metrics by type
# TYPE nr_stats_metrics_total_timeseries_by_type gauge
nr_stats_metrics_total_timeseries_by_type{type="counter"} 114
nr_stats_metrics_total_timeseries_by_type{type="gauge"} 313
nr_stats_metrics_total_timeseries_by_type{type="histogram"} 5
nr_stats_metrics_total_timeseries_by_type{type="summary"} 2
nr_stats_metrics_total_timeseries_by_type{type="untyped"} 44
# HELP nr_stats_targets Discovered targets
# TYPE nr_stats_targets gauge
nr_stats_targets{retriever="fixed"} 1
nr_stats_targets{retriever="kubernetes"} 1
```

No remaining kube-state-metric metric related

Fix #95 