### PR TITLE
Collector and instrumentation info

### DIFF
--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -135,10 +135,17 @@ func RunWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 			{
 				MetricPrefix: "",
 				Attributes: map[string]interface{}{
-					"k8s.cluster.name":   cfg.ClusterName,
-					"clusterName":        cfg.ClusterName,
+					"k8s.cluster.name": cfg.ClusterName,
+					"clusterName":      cfg.ClusterName,
+					//Keeping these for backward compatibility
 					"integrationVersion": integration.Version,
 					"integrationName":    integration.Name,
+					//Since the agent is not used we add the attributes manually
+					"collector.name":           integration.Name,
+					"collector.version":        integration.Version,
+					"instrumentation.name":     integration.Name,
+					"instrumentation.version":  integration.Version,
+					"instrumentation.provider": "newRelic",
 				},
 			},
 		},


### PR DESCRIPTION
### Use Case
The aim of the PR is to add to each metrics the data needed to customer and agents to properly detect the source of such data.

In particular two "categories" have been added:
 - `collector` indicates the component sending the data. 
For example `nri-prometheus` in standalone mode sends metric with `collector.name=nri-prometheus`. If it sends metrics through the agent the  `collector.name=infrastructure-agent`
 - `instrumentation` category contains info regarding the integration that fetched the data

#### Note

The provider is currently hardcoded, but we might consider in the future to make it configurable through the SDK

We might add in the future more common attributes, for example `exporter` indicating the exporter and the version of the exporter exposing the data. So far we did not have a proper way to fetch that data.

In the agent there is an other PR aiming to do the same when the data is sent with `standalonemode=false`

Fix https://github.com/newrelic/nri-prometheus/issues/93