### PR TITLE
Reworked example transformation section, added worker_threads, and isolated defaults

### DIFF
--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -83,42 +83,53 @@ data:
     # The name of your cluster. It's important to match other New Relic products to relate the data.
     cluster_name: "<YOUR_CLUSTER_NAME>"
 
-    # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data. Defaults to true
+    # When standalone is set to false nri-prometheus requires an infrastructure agent to work and send data. 
+    # Default: true
     # standalone: true
 
-    # How often the integration should run. Defaults to 30s.
+    # How often the integration should run. 
+    # Default: "30s"
     # scrape_duration: "30s"
 
-    # The HTTP client timeout when fetching data from endpoints. Defaults to 5s.
+    # The HTTP client timeout when fetching data from endpoints. 
+    # Default: "5s"
     # scrape_timeout: "5s"
 
     # How old must the entries used for calculating the counters delta be
-    # before the telemetry emitter expires them. Defaults to 5m.
+    # before the telemetry emitter expires them. 
+    # Default: "5m"
     # telemetry_emitter_delta_expiration_age: "5m"
 
     # How often must the telemetry emitter check for expired delta entries.
-    # Defaults to 5m.
+    # Default: "5m"
     # telemetry_emitter_delta_expiration_check_interval: "5m"
 
-    # Wether the integration should run in verbose mode or not. Defaults to false.
+    # Wether the integration should run in verbose mode or not. 
+    # Default: false
     verbose: false
 
     # Whether the integration should run in audit mode or not. Defaults to false.
     # Audit mode logs the uncompressed data sent to New Relic. Use this to log all data sent.
     # It does not include verbose mode. This can lead to a high log volume, use with care.
+    # Default: false
     audit: false
 
-    # Wether the integration should skip TLS verification or not. Defaults to false.
+    # Wether the integration should skip TLS verification or not. 
+    # Default: false
     insecure_skip_verify: false
 
-    # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
+    # The label used to identify scrapable targets.
+    # Targets can be identified using a label or annotation.
+    # Default: "prometheus.io/scrape"
     scrape_enabled_label: "prometheus.io/scrape"
 
-    # Whether k8s nodes need to be labelled to be scraped or not. Defaults to true.
+    # Whether k8s nodes need to be labelled to be scraped or not. 
+    # Default: true
     require_scrape_enabled_label_for_nodes: true
 
-    # Number of worker threads used for scraping targets. Defaults to 4.
+    # Number of worker threads used for scraping targets.
     # For large clusters with many endpoints, increase to 10.
+    # Default: 4
     # worker_threads: 4
 
     # targets:
@@ -142,11 +153,12 @@ data:
     # emitter_ca_file: "/path/to/cert/server.pem"
 
     # Set to true in order to stop autodiscovery in the k8s cluster. It can be useful when running the Pod with a service account
-    # having limited privileges. Defaults to false.
+    # having limited privileges. 
+    # Default: false
     # disable_autodiscovery: false
 
     # Whether the emitter should skip TLS verification when submitting data.
-    # Defaults to false.
+    # Default: false
     # emitter_insecure_skip_verify: false
 
     # Histogram support is based on New Relic's guidelines for higher

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -117,6 +117,10 @@ data:
     # Whether k8s nodes need to be labelled to be scraped or not. Defaults to true.
     require_scrape_enabled_label_for_nodes: true
 
+    # Number of worker threads used for scraping targets. Defaults to 4.
+    # For large clusters with many endpoints, increase to 10.
+    # worker_threads: 4
+
     # targets:
     #   - description: Secure etcd example
     #     urls: ["https://192.168.3.1:2379", "https://192.168.3.2:2379", "https://192.168.3.3:2379"]
@@ -157,7 +161,7 @@ data:
     #   - 99
 
     # transformations:
-    #   - description: "General processing rules"
+    #   - description: "Uncomment if running New Relic Kubernetes Integration"
     #     rename_attributes:
     #       - metric_prefix: ""
     #         attributes:
@@ -169,22 +173,17 @@ data:
     #           pod: "podName"
     #           deployment: "deploymentName"
     #     ignore_metrics:
-    #       # Ignore all the metrics except the ones listed below.
-    #       # This is a list that complements the data retrieved by the New
-    #       # Relic Kubernetes Integration, that's why Pods and containers are
-    #       # not included, because they are already collected by the
-    #       # Kubernetes Integration.
-    #       - except:
-    #         - kube_hpa_
+    #       - prefixes:
     #         - kube_daemonset_
-    #         - kube_statefulset_
+    #         - kube_deployment_
     #         - kube_endpoint_
-    #         - kube_service_
-    #         - kube_limitrange
+    #         - kube_namespace_
     #         - kube_node_
-    #         - kube_poddisruptionbudget_
-    #         - kube_resourcequota
-    #         - nr_stats
+    #         - kube_persistentvolume_
+    #         - kube_pod_
+    #         - kube_replicaset_
+    #         - kube_service_
+    #         - kube_statefulset_
     #     copy_attributes:
     #       # Copy all the labels from the timeseries with metric name
     #       # `kube_hpa_labels` into every timeseries with a metric name that


### PR DESCRIPTION
Changes:

- Moved default settings to their own line so that it's easier to find
- Added `worker_threads`
- Modified example `transformations` to exclude metrics collected by our Daemonset