### PR TITLE
goreleaser: use full import path in ldflags -X

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ builds:
     main: ./cmd/nri-prometheus/
     binary: nri-prometheus
     ldflags:
-      - -s -w -X internal/integration/integration.Version={{.Version}} #-X main.gitCommit={{.Commit}} -X main.buildDate={{.Date}}
+      - -s -w -X github.com/newrelic/nri-prometheus/internal/integration.Version={{.Version}} #-X main.gitCommit={{.Commit}} -X main.buildDate={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -27,7 +27,7 @@ builds:
     main: ./cmd/nri-prometheus/
     binary: nri-prometheus
     ldflags:
-      - -s -w -X internal/integration/integration.Version={{.Version}} #-X main.gitCommit={{.Commit}} -X main.buildDate={{.Date}}
+      - -s -w -X github.com/newrelic/nri-prometheus/internal/integration.Version={{.Version}} #-X main.gitCommit={{.Commit}} -X main.buildDate={{.Date}}
     goos:
       - windows
     goarch:


### PR DESCRIPTION
## Background

Linker flag `-X` allows to overwrite a variable value at link time give its import path. Right now, a relative import path is provided, which does not seem to work. This PR changes the path to be absolute, which I have confirmed to work on my local machine.

---
Fixes #114 

