### PR TITLE
ci: remove load test from PR

### DIFF
--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -4,7 +4,6 @@ on:
       - v*
     branches:
       - main
-  pull_request:
 
 name: Load Tests
 jobs:


### PR DESCRIPTION
This PR removes the load test on PR since it uses secrets and are not available for external users.