### PR TITLE
chore: remove definition path from config sample

### DIFF
--- a/configs/nri-prometheus-config.yml.sample
+++ b/configs/nri-prometheus-config.yml.sample
@@ -43,9 +43,4 @@ integrations:
       # Whether the integration should skip TLS verification or not. Defaults to false.
       insecure_skip_verify: false
 
-      # integration definition files required to map metrics to entities
-      definition_files_path: /etc/newrelic-infra/definition-files
-
     timeout: 10s
-
-

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -123,8 +123,6 @@ data:
     #          container: "containerName"
     #          pod: "podName"
     #          deployment: "deploymentName"
-    # integration definition files required to map metrics to entities
-    # definition_files_path: /etc/newrelic-infra/definition-files
 kind: ConfigMap
 metadata:
   name: nri-prometheus-cfg

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -236,8 +236,6 @@ data:
     #         match_by:
     #           - namespace
     #           - node
-    # integration definition files required to map metrics to entities
-    # definition_files_path: /etc/newrelic-infra/definition-files
 kind: ConfigMap
 metadata:
   name: nri-prometheus-cfg


### PR DESCRIPTION
These definitions aren't ready to be used - it's better to remove it
from the config sample.