### PR TITLE
 fix(endpoints): scrape endpoints and not services

### DIFF
--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -1,9 +1,8 @@
 on:
   push:
-    tags:
-      - v*
     branches:
       - main
+  pull_request:
 
 name: Load Tests
 jobs:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -2,8 +2,6 @@ name: Push/PR pipeline
 
 on:
   push:
-    tags:
-      - v*
     branches:
       - main
   pull_request:

--- a/cmd/k8s-target-retriever/main.go
+++ b/cmd/k8s-target-retriever/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	kubeconf := endpoints.WithKubeConfig(*kubeConfigFile)
-	ktr, err := endpoints.NewKubernetesTargetRetriever("prometheus.io/scrape", false, kubeconf)
+	ktr, err := endpoints.NewKubernetesTargetRetriever("prometheus.io/scrape", false, true, true, kubeconf)
 	if err != nil {
 		logrus.Fatalf("could not create KubernetesTargetRetriever: %v", err)
 	}

--- a/cmd/k8s-target-retriever/main.go
+++ b/cmd/k8s-target-retriever/main.go
@@ -55,7 +55,5 @@ func main() {
 			logrus.Infof("%s[%s] %s", b.Name, b.Object.Kind, b.URL.String())
 		}
 		logrus.Infof("###################################")
-
-		logrus.Println()
 	}
 }

--- a/cmd/k8s-target-retriever/main.go
+++ b/cmd/k8s-target-retriever/main.go
@@ -44,14 +44,17 @@ func main() {
 
 	logrus.Infoln("connected to cluster, watching for targets")
 
-	for range time.Tick(time.Second * 5) {
+	for range time.Tick(time.Second * 7) {
 		targets, err := ktr.GetTargets()
+		logrus.Infof("###################################")
+
 		if err != nil {
 			logrus.Fatalf("could not get targets: %v", err)
 		}
 		for _, b := range targets {
 			logrus.Infof("%s[%s] %s", b.Name, b.Object.Kind, b.URL.String())
 		}
+		logrus.Infof("###################################")
 
 		logrus.Println()
 	}

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -109,6 +109,8 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("insecure_skip_verify", false)
 	viper.SetDefault("standalone", true)
 	viper.SetDefault("disable_autodiscovery", false)
+	viper.SetDefault("scrape_services", true)
+	viper.SetDefault("scrape_endpoints", false)
 	viper.SetDefault("percentiles", []float64{50.0, 95.0, 99.0})
 	viper.SetDefault("worker_threads", 4)
 }

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -18,6 +18,7 @@ rules:
     - "nodes/proxy"
     - "pods"
     - "services"
+    - "endpoints"
   verbs: ["get", "list", "watch"]
 - nonResourceURLs:
   - /metrics

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -87,7 +87,13 @@ data:
     # standalone: true
     # How often the integration should run. Defaults to 30s.
     # scrape_duration: "30s"
-    # The HTTP client timeout when fetching data from endpoints. Defaults to 30s.
+    # The HTTP client timeout when fetching data from targets. Defaults to 30s.
+    # scrape_services Allows to enable scraping the service and not the endpoints behind.
+    # When endpoints are scraped this is no longer needed
+    scrape_services: true
+    # scrape_endpoints Allows to enable scraping directly endpoints instead of services as prometheus service natively does.
+    # Please notice that depending on the number of endpoints behind a service the load can increase considerably
+    scrape_endpoints: false
     # scrape_timeout: "30s"
     # Wether the integration should run in verbose mode or not. Defaults to false.
     verbose: false

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -18,6 +18,7 @@ rules:
     - "nodes/proxy"
     - "pods"
     - "services"
+    - "endpoints"
   verbs: ["get", "list", "watch"]
 - nonResourceURLs:
   - /metrics

--- a/deploy/nri-prometheus.tmpl.yaml
+++ b/deploy/nri-prometheus.tmpl.yaml
@@ -90,7 +90,7 @@ data:
     # How often the integration should run. Defaults to 30s.
     # scrape_duration: "30s"
 
-    # The HTTP client timeout when fetching data from endpoints. Defaults to 5s.
+    # The HTTP client timeout when fetching data from targets. Defaults to 5s.
     # scrape_timeout: "5s"
 
     # How old must the entries used for calculating the counters delta be
@@ -115,11 +115,19 @@ data:
     # The label used to identify scrapable targets. Defaults to "prometheus.io/scrape".
     scrape_enabled_label: "prometheus.io/scrape"
 
+    # scrape_services Allows to enable scraping the service and not the endpoints behind.
+    # When endpoints are scraped this is no longer needed
+    scrape_services: true
+
+    # scrape_endpoints Allows to enable scraping directly endpoints instead of services as prometheus service natively does.
+    # Please notice that depending on the number of endpoints behind a service the load can increase considerably
+    scrape_endpoints: false
+
     # Whether k8s nodes need to be labelled to be scraped or not. Defaults to true.
     require_scrape_enabled_label_for_nodes: true
 
     # Number of worker threads used for scraping targets.
-    # For large clusters with many (>400) endpoints, slowly increase until scrape
+    # For large clusters with many (>400) targets, slowly increase until scrape
     # time falls between the desired `scrape_duration`.
     # Increasing this value too much will result in huge memory consumption if too
     # many metrics are being scraped.

--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -34,6 +34,8 @@ type Config struct {
 	ScrapeTimeout                     time.Duration                `mapstructure:"scrape_timeout"`
 	Standalone                        bool                         `mapstructure:"standalone"`
 	DisableAutodiscovery              bool                         `mapstructure:"disable_autodiscovery"`
+	ScrapeServices                    bool                         `mapstructure:"scrape_services"`
+	ScrapeEndpoints                   bool                         `mapstructure:"scrape_endpoints"`
 	ScrapeDuration                    string                       `mapstructure:"scrape_duration"`
 	EmitterHarvestPeriod              string                       `mapstructure:"emitter_harvest_period"`
 	MinEmitterHarvestPeriod           string                       `mapstructure:"min_emitter_harvest_period"`
@@ -125,7 +127,7 @@ func RunWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 	retrievers = append(retrievers, fixedRetriever)
 
 	if !cfg.DisableAutodiscovery {
-		kubernetesRetriever, err := endpoints.NewKubernetesTargetRetriever(cfg.ScrapeEnabledLabel, cfg.RequireScrapeEnabledLabelForNodes, endpoints.WithInClusterConfig())
+		kubernetesRetriever, err := endpoints.NewKubernetesTargetRetriever(cfg.ScrapeEnabledLabel, cfg.RequireScrapeEnabledLabelForNodes, cfg.ScrapeServices, cfg.ScrapeEndpoints, endpoints.WithInClusterConfig())
 		if err != nil {
 			logrus.WithError(err).Errorf("not possible to get a Kubernetes client. If you aren't running this integration in a Kubernetes cluster, you can ignore this error")
 		} else {

--- a/internal/pkg/endpoints/endpoints.go
+++ b/internal/pkg/endpoints/endpoints.go
@@ -18,7 +18,7 @@ type TargetRetriever interface {
 	Name() string
 }
 
-// Object represents a kubernetes object like a pod or a service.
+// Object represents a kubernetes object like a pod or a service or an endpoint.
 type Object struct {
 	Name   string
 	Kind   string

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -627,7 +627,7 @@ func (k *KubernetesTargetRetriever) processEvent(event watch.Event, requireLabel
 					}
 				}
 			}
-		} else if !requireLabel {
+		} else {
 			// If the object doesn't require label and was not seen before, we add it.
 			if !seen {
 				k.addTarget(object, event.Type)

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -669,8 +669,10 @@ func (k *KubernetesTargetRetriever) isEventScrapable(object metav1.Object) bool 
 	return scrapable
 }
 
-// addTarget adds the target to the cache
+// addTarget adds the target to the cache k.targets
 func (k *KubernetesTargetRetriever) addTarget(object metav1.Object, event watch.EventType) {
+	// targets variable stores a list of n httpEndpoints linked to an object.
+	// That will be stored into the k.targets map having object.uuid as key
 	var targets []Target
 	var err error
 	switch obj := object.(type) {

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -247,6 +247,9 @@ func endpointsTargets(e *apiv1.Endpoints, s *apiv1.Service) []Target {
 			if !contains(portList, port) {
 				continue
 			}
+			if eSubPort.Protocol != apiv1.ProtocolTCP {
+				continue
+			}
 
 			// we are skipping eSub.NotReadyAddresses
 			for _, eSubAddr := range subset.Addresses {
@@ -270,6 +273,9 @@ func getPortList(e *apiv1.Endpoints, s *apiv1.Service) []string {
 	} else {
 		for _, subset := range e.Subsets {
 			for _, port := range subset.Ports {
+				if port.Protocol != apiv1.ProtocolTCP {
+					continue
+				}
 				if len(subset.Addresses) != 0 {
 					portList = append(portList, strconv.FormatInt(int64(port.Port), 10))
 				}

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -681,6 +681,8 @@ func newFakeKubernetesTargetRetriever(client *fake.Clientset) *KubernetesTargetR
 		client:             client,
 		targets:            new(sync.Map),
 		scrapeEnabledLabel: "prometheus.io/scrape",
+		scrapeServices:     true,
+		scrapeEndpoints:    true,
 	}
 }
 

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -50,7 +50,8 @@ func TestWatch_Endpoints(t *testing.T) {
 		}
 
 		target := targets[0]
-		if target.Name != "my-endpoints" {
+
+		if target.Name != endpointsName {
 			return errors.New("target name didn't match")
 		}
 		var listURLs []string
@@ -100,7 +101,7 @@ func TestWatch_EndpointsSinglePort(t *testing.T) {
 		}
 
 		target := targets[0]
-		if target.Name != "my-endpoints" {
+		if target.Name != endpointsName {
 			return errors.New("target name didn't match")
 		}
 		var listURLs []string
@@ -148,7 +149,7 @@ func TestWatch_EndpointsModify(t *testing.T) {
 			return errors.New("targets len didn't match")
 		}
 		target := targets[0]
-		if target.Name != "my-endpoints" {
+		if target.Name != endpointsName {
 			return errors.New("target name didn't match")
 		}
 		var listURLs []string
@@ -173,11 +174,13 @@ func TestWatch_EndpointsModify(t *testing.T) {
 	}
 }
 
+const endpointsName = "my-endpoints"
+
 func populateFakeEndpointsData(clientset *fake.Clientset) error {
 	e := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("niceUid"),
-			Name: "my-endpoints",
+			Name: endpointsName,
 			Labels: map[string]string{
 				// this labels should be ignored
 				"prometheus.io/scrape": "false",
@@ -236,7 +239,7 @@ func populateFakeEndpointsData(clientset *fake.Clientset) error {
 	}
 	s := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-endpoints",
+			Name: endpointsName,
 			Labels: map[string]string{
 				// This labels should be overwritten
 				"prometheus.io/scrape": "false",
@@ -265,7 +268,7 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 	e := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("niceUid"),
-			Name: "my-endpoints",
+			Name: endpointsName,
 			Labels: map[string]string{
 				// this labels should be ignored
 				"prometheus.io/scrape": "false",
@@ -324,7 +327,7 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 	}
 	s := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-endpoints",
+			Name: endpointsName,
 			Labels: map[string]string{
 				// This labels should be overwritten
 				"prometheus.io/scrape": "false",
@@ -355,7 +358,7 @@ func populateFakeEndpointsDataWithModify(clientset *fake.Clientset) error {
 	e := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("niceUid"),
-			Name: "my-endpoints",
+			Name: endpointsName,
 		},
 		Subsets: []v1.EndpointSubset{
 			v1.EndpointSubset{
@@ -401,7 +404,7 @@ func populateFakeEndpointsDataWithModify(clientset *fake.Clientset) error {
 
 	s := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-endpoints",
+			Name: endpointsName,
 			Labels: map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/path":   "/metrics",

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -213,10 +213,12 @@ func populateFakeEndpointsData(clientset *fake.Clientset) error {
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Port: 1,
+						Port:     1,
+						Protocol: v1.ProtocolTCP,
 					},
 					{
-						Port: 2,
+						Port:     2,
+						Protocol: v1.ProtocolTCP,
 					},
 				},
 			},
@@ -228,10 +230,12 @@ func populateFakeEndpointsData(clientset *fake.Clientset) error {
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Port: 3,
+						Port:     3,
+						Protocol: v1.ProtocolTCP,
 					},
 					{
-						Port: 4,
+						Port:     4,
+						Protocol: v1.ProtocolTCP,
 					},
 				},
 			},
@@ -301,10 +305,12 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Port: 1,
+						Port:     1,
+						Protocol: v1.ProtocolTCP,
 					},
 					{
-						Port: 2,
+						Port:     2,
+						Protocol: v1.ProtocolTCP,
 					},
 				},
 			},
@@ -316,10 +322,12 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Port: 3,
+						Port:     3,
+						Protocol: v1.ProtocolTCP,
 					},
 					{
-						Port: 4,
+						Port:     4,
+						Protocol: v1.ProtocolTCP,
 					},
 				},
 			},
@@ -377,10 +385,12 @@ func populateFakeEndpointsDataWithModify(clientset *fake.Clientset) error {
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Port: 1,
+						Port:     1,
+						Protocol: v1.ProtocolTCP,
 					},
 					{
-						Port: 2,
+						Port:     2,
+						Protocol: v1.ProtocolTCP,
 					},
 				},
 			},
@@ -392,10 +402,12 @@ func populateFakeEndpointsDataWithModify(clientset *fake.Clientset) error {
 				},
 				Ports: []v1.EndpointPort{
 					{
-						Port: 3,
+						Port:     3,
+						Protocol: v1.ProtocolTCP,
 					},
 					{
-						Port: 4,
+						Port:     4,
+						Protocol: v1.ProtocolTCP,
 					},
 				},
 			},

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -12,6 +12,8 @@ source ./load-test/laod_test.sh
 runLoadTest
 ```
 
+In some environment you will need to uncomment the command"dos2unix ./load-test/load_test.results" in load_test.sh
+
 The image is compiled, deployed with `Skaffold`, the load test chart is deployed with 800 targets and the results from the
 prometheus output are collected and parsed with a golang help tool.
 

--- a/load-test/laod_test.sh
+++ b/load-test/laod_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 #Clean away old resources not useful anymore
 cleanOldResources(){
   kubectl delete namespace newrelic-load || true
@@ -29,7 +27,7 @@ retrieveResults(){
   kubectl logs ${POD}
   kubectl exec -n default ${POD} -- wget localhost:8080/metrics -q -O - > ./load-test/load_test.results
   # Debug This might be needed when developing locally
-  # dos2unix ./load-test/load_test.results
+  #dos2unix ./load-test/load_test.results
 }
 
 #Verify the results of the tests (memory, time elapsed, total targets)
@@ -39,12 +37,17 @@ verifyResults(){
 }
 
 runLoadTest(){
-  cleanOldResources
-  deployLoadTestEnvironment
-  deployCurrentNriPrometheus
-  sleep 180
-  retrieveResults
-  verifyResults
+  if [ -z "$NEWRELIC_LICENSE" ]
+  then
+    echo "NEWRELIC_LICENSE environment variable should be set"
+  else
+    cleanOldResources
+    deployLoadTestEnvironment
+    deployCurrentNriPrometheus
+    sleep 180
+    retrieveResults
+    verifyResults
+  fi
 }
 
 


### PR DESCRIPTION
Fix https://github.com/newrelic/nri-prometheus/issues/27

The idea is that when a service is detected the underlying endpoints are fetched. For backward compatibility the metric directly coming from the service is kept
<img width="1208" alt="Screen Shot 2021-03-10 at 11 57 09 AM" src="https://user-images.githubusercontent.com/43335750/110619157-c0d28900-8197-11eb-9ced-c6534d16c3d8.png">

Two new config options have been added `ScrapeServices (default true)` and `ScrapeEndpoints(default false)`
 
 After merging we should update documentation and the helm chart to ask for listing/watching permission on endpoints