### PR TITLE
log deltas being dropped due to invalid calculation

### DIFF
--- a/internal/integration/telemetry_sdk_emitter.go
+++ b/internal/integration/telemetry_sdk_emitter.go
@@ -207,9 +207,11 @@ func (te *TelemetryEmitter) Emit(metrics []Metric) error {
 				metric.value.(float64),
 				now,
 			)
-			if ok {
-				te.harvester.RecordMetric(m)
+			if !ok {
+				logrus.Infof("Got invalid delta for %s=%v, skipping", metric.name, metric.value)
+				continue
 			}
+			te.harvester.RecordMetric(m)
 		case metricType_SUMMARY:
 			if err := te.emitSummary(metric, now); err != nil {
 				if results == nil {


### PR DESCRIPTION
This PR adds an INFO logs when datapoints of DELTA (COUNTER) metrics cannot be calculated, which may happen when such points do not arrive in order from the exporter.