### PR TITLE
Buffer the full page in the scraper to expose unexpected EOF.

### DIFF
--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -57,9 +57,9 @@ func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 	if err != nil {
 		return mfs, err
 	}
-	b := bytes.NewBuffer(body)
+	r := bytes.NewReader(body)
 
-	d := expfmt.NewDecoder(b, expfmt.FmtText)
+	d := expfmt.NewDecoder(r, expfmt.FmtText)
 	for {
 		var mf dto.MetricFamily
 		if err := d.Decode(&mf); err != nil {

--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -4,8 +4,10 @@
 package prometheus
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -20,21 +22,6 @@ type MetricFamiliesByName map[string]dto.MetricFamily
 // HTTPDoer executes http requests. It is implemented by *http.Client.
 type HTTPDoer interface {
 	Do(req *http.Request) (*http.Response, error)
-}
-
-type countReadCloser struct {
-	innerReadCloser io.ReadCloser
-	count           int
-}
-
-func (rc *countReadCloser) Close() error {
-	return rc.innerReadCloser.Close()
-}
-
-func (rc *countReadCloser) Read(p []byte) (n int, err error) {
-	n, err = rc.innerReadCloser.Read(p)
-	rc.count += n
-	return
 }
 
 // ResetTotalScrapedPayload resets the integration totalScrapedPayload
@@ -62,16 +49,17 @@ func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 		return mfs, err
 	}
 
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
 	if resp.StatusCode < 200 || resp.StatusCode > 300 {
 		return nil, fmt.Errorf("status code returned by the prometheus exporter indicates an error occurred: %d", resp.StatusCode)
 	}
 
-	countedBody := &countReadCloser{innerReadCloser: resp.Body}
-	d := expfmt.NewDecoder(countedBody, expfmt.FmtText)
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return mfs, err
+	}
+	b := bytes.NewBuffer(body)
+
+	d := expfmt.NewDecoder(b, expfmt.FmtText)
 	for {
 		var mf dto.MetricFamily
 		if err := d.Decode(&mf); err != nil {
@@ -83,7 +71,7 @@ func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 		mfs[mf.GetName()] = mf
 	}
 
-	bodySize := float64(countedBody.count)
+	bodySize := float64(len(body))
 	targetSize.With(prom.Labels{"target": url}).Set(bodySize)
 	totalScrapedPayload.Add(bodySize)
 	return mfs, nil


### PR DESCRIPTION
Hi there folks! 👋 

We're seeing some pretty wild flapping of our SLI which is a composition of 2 different metrics. We see this flapping on deploy.

![](https://staging-gorgon.nr-assets.net/image/580e562e-20af-4f1c-9700-e596b70f4ee9?type=line)

We believe we've tracked this down to the behavior of nri-prometheus when a page is only partially loaded:
https://github.com/a-feld/prometheus-unexpected-eof

When a page is partially loaded, an `unexpected EOF` error is raised, but is squashed by the prometheus decoder. This PR exposes the `unexpected EOF` error (io.ErrUnexpectedEOF) and avoids only partially reporting metrics which can lead to weird behavior of metrics that are compositions in the UI.