### PR TITLE
endpoints: check for path prefix with strings.HasPrefix

### DIFF
--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -286,20 +286,20 @@ func getPortList(e *apiv1.Endpoints, s *apiv1.Service) []string {
 
 func getPath(o metav1.Object) string {
 	var path string
-	var ok bool
 
 	// Annotations take precedence over labels.
-	if _, ok = o.GetAnnotations()[defaultScrapePathLabel]; ok {
-		path, _ = o.GetAnnotations()[defaultScrapePathLabel]
-	} else if path, ok = o.GetLabels()[defaultScrapePathLabel]; ok {
-		path, _ = o.GetLabels()[defaultScrapePathLabel]
+	if annotation, ok := o.GetAnnotations()[defaultScrapePathLabel]; ok {
+		path = annotation
+	} else if label, ok := o.GetLabels()[defaultScrapePathLabel]; ok {
+		path = label
 	} else {
 		path = defaultScrapePath
 	}
 
-	if path[0] != '/' {
+	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
+
 	return path
 }
 


### PR DESCRIPTION
Previously, path[0] was used which caused a panic for empty labels
This will _allow_ the use of an empty label value, which will be translated to "/"

Fixes #181 