### PR TITLE
internal: various improvements

### DIFF
--- a/internal/integration/bounded_harvester_test.go
+++ b/internal/integration/bounded_harvester_test.go
@@ -24,6 +24,8 @@ func (h *mockHarvester) HarvestNow(ctx context.Context) {
 // Checks that bindHarvester returns a harvester, correctly overriding settings
 // Also check the async routine is spawned
 func TestBindHarvester(t *testing.T) {
+	t.Parallel()
+
 	cfg := BoundedHarvesterCfg{
 		MetricCap:                0,
 		HarvestPeriod:            1,
@@ -59,6 +61,8 @@ func TestBindHarvester(t *testing.T) {
 }
 
 func TestHarvestRoutine(t *testing.T) {
+	t.Parallel()
+
 	cfg := BoundedHarvesterCfg{
 		HarvestPeriod:     300 * time.Millisecond,
 		MinReportInterval: BoundedHarvesterDefaultMinReportInterval,
@@ -80,6 +84,8 @@ func TestHarvestRoutine(t *testing.T) {
 }
 
 func TestRoutineStopChannel(t *testing.T) {
+	t.Parallel()
+
 	cfg := BoundedHarvesterCfg{
 		HarvestPeriod:     300 * time.Millisecond,
 		MinReportInterval: BoundedHarvesterDefaultMinReportInterval,
@@ -105,6 +111,8 @@ func TestRoutineStopChannel(t *testing.T) {
 }
 
 func TestRoutineStopFlag(t *testing.T) {
+	t.Parallel()
+
 	cfg := BoundedHarvesterCfg{
 		HarvestPeriod:     300 * time.Millisecond,
 		MinReportInterval: BoundedHarvesterDefaultMinReportInterval,
@@ -130,6 +138,8 @@ func TestRoutineStopFlag(t *testing.T) {
 }
 
 func TestHarvestNow(t *testing.T) {
+	t.Parallel()
+
 	cfg := BoundedHarvesterCfg{
 		DisablePeriodicReporting: true,
 	}
@@ -151,6 +161,8 @@ func TestHarvestNow(t *testing.T) {
 }
 
 func TestMetricCap(t *testing.T) {
+	t.Parallel()
+
 	cfg := BoundedHarvesterCfg{
 		HarvestPeriod: time.Hour,
 		MetricCap:     3,

--- a/internal/integration/emitter_test.go
+++ b/internal/integration/emitter_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Test_EmitterCanEmit(t *testing.T) {
+	t.Parallel()
+
 	summary, err := newSummary(3, 10, []*quantile{{0.5, 10}, {0.999, 100}})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/integration/fetcher_test.go
+++ b/internal/integration/fetcher_test.go
@@ -204,11 +204,11 @@ func TestConvertPromMetrics(t *testing.T) {
 								SampleCount: &(&struct{ x uint64 }{10}).x,
 								SampleSum:   &(&struct{ x float64 }{42}).x,
 								Bucket: []*dto.Bucket{
-									&dto.Bucket{
+									{
 										CumulativeCount: &(&struct{ x uint64 }{42}).x,
 										UpperBound:      &(&struct{ x float64 }{100}).x,
 									},
-									&dto.Bucket{
+									{
 										CumulativeCount: &(&struct{ x uint64 }{24}).x,
 										UpperBound:      &(&struct{ x float64 }{50}).x,
 									},
@@ -234,11 +234,11 @@ func TestConvertPromMetrics(t *testing.T) {
 								SampleCount: &(&struct{ x uint64 }{10}).x,
 								SampleSum:   &(&struct{ x float64 }{42}).x,
 								Quantile: []*dto.Quantile{
-									&dto.Quantile{
+									{
 										Quantile: &(&struct{ x float64 }{0.5}).x,
 										Value:    &(&struct{ x float64 }{100}).x,
 									},
-									&dto.Quantile{
+									{
 										Quantile: &(&struct{ x float64 }{0.9}).x,
 										Value:    &(&struct{ x float64 }{200}).x,
 									},
@@ -279,11 +279,11 @@ func TestConvertPromMetrics(t *testing.T) {
 						SampleCount: &(&struct{ x uint64 }{10}).x,
 						SampleSum:   &(&struct{ x float64 }{42}).x,
 						Bucket: []*dto.Bucket{
-							&dto.Bucket{
+							{
 								CumulativeCount: &(&struct{ x uint64 }{42}).x,
 								UpperBound:      &(&struct{ x float64 }{100}).x,
 							},
-							&dto.Bucket{
+							{
 								CumulativeCount: &(&struct{ x uint64 }{24}).x,
 								UpperBound:      &(&struct{ x float64 }{50}).x,
 							},
@@ -304,11 +304,11 @@ func TestConvertPromMetrics(t *testing.T) {
 						SampleCount: &(&struct{ x uint64 }{10}).x,
 						SampleSum:   &(&struct{ x float64 }{42}).x,
 						Quantile: []*dto.Quantile{
-							&dto.Quantile{
+							{
 								Quantile: &(&struct{ x float64 }{0.5}).x,
 								Value:    &(&struct{ x float64 }{100}).x,
 							},
-							&dto.Quantile{
+							{
 								Quantile: &(&struct{ x float64 }{0.9}).x,
 								Value:    &(&struct{ x float64 }{200}).x,
 							},
@@ -376,11 +376,11 @@ func TestConvertPromMetrics(t *testing.T) {
 								SampleCount: &(&struct{ x uint64 }{20}).x,
 								SampleSum:   &(&struct{ x float64 }{52}).x,
 								Bucket: []*dto.Bucket{
-									&dto.Bucket{
+									{
 										CumulativeCount: &(&struct{ x uint64 }{52}).x,
 										UpperBound:      &(&struct{ x float64 }{200}).x,
 									},
-									&dto.Bucket{
+									{
 										CumulativeCount: &(&struct{ x uint64 }{34}).x,
 										UpperBound:      &(&struct{ x float64 }{60}).x,
 									},
@@ -406,11 +406,11 @@ func TestConvertPromMetrics(t *testing.T) {
 								SampleCount: &(&struct{ x uint64 }{20}).x,
 								SampleSum:   &(&struct{ x float64 }{52}).x,
 								Quantile: []*dto.Quantile{
-									&dto.Quantile{
+									{
 										Quantile: &(&struct{ x float64 }{0.5}).x,
 										Value:    &(&struct{ x float64 }{42}).x,
 									},
-									&dto.Quantile{
+									{
 										Quantile: &(&struct{ x float64 }{0.9}).x,
 										Value:    &(&struct{ x float64 }{24}).x,
 									},
@@ -451,11 +451,11 @@ func TestConvertPromMetrics(t *testing.T) {
 						SampleCount: &(&struct{ x uint64 }{20}).x,
 						SampleSum:   &(&struct{ x float64 }{52}).x,
 						Bucket: []*dto.Bucket{
-							&dto.Bucket{
+							{
 								CumulativeCount: &(&struct{ x uint64 }{52}).x,
 								UpperBound:      &(&struct{ x float64 }{200}).x,
 							},
-							&dto.Bucket{
+							{
 								CumulativeCount: &(&struct{ x uint64 }{34}).x,
 								UpperBound:      &(&struct{ x float64 }{60}).x,
 							},
@@ -476,11 +476,11 @@ func TestConvertPromMetrics(t *testing.T) {
 						SampleCount: &(&struct{ x uint64 }{20}).x,
 						SampleSum:   &(&struct{ x float64 }{52}).x,
 						Quantile: []*dto.Quantile{
-							&dto.Quantile{
+							{
 								Quantile: &(&struct{ x float64 }{0.5}).x,
 								Value:    &(&struct{ x float64 }{42}).x,
 							},
-							&dto.Quantile{
+							{
 								Quantile: &(&struct{ x float64 }{0.9}).x,
 								Value:    &(&struct{ x float64 }{24}).x,
 							},

--- a/internal/integration/fetcher_test.go
+++ b/internal/integration/fetcher_test.go
@@ -42,7 +42,11 @@ func TestFetcher(t *testing.T) {
 
 	// When it fetches data synchronously
 	addr := url.URL{Scheme: "http", Path: "hello/metrics"}
-	pairsCh := fetcher.Fetch([]endpoints.Target{endpoints.New("", addr, endpoints.Object{})})
+	pairsCh := fetcher.Fetch([]endpoints.Target{
+		{
+			URL: addr,
+		},
+	})
 
 	var pair TargetMetrics
 	select {
@@ -81,8 +85,12 @@ func TestFetcher_Error(t *testing.T) {
 	fail := url.URL{Scheme: "http", Path: "fail/metrics"}
 	hello := url.URL{Scheme: "http", Path: "hello/metrics"}
 	pairsCh := fetcher.Fetch([]endpoints.Target{
-		endpoints.New("", fail, endpoints.Object{}),
-		endpoints.New("", hello, endpoints.Object{}),
+		{
+			URL: fail,
+		},
+		{
+			URL: hello,
+		},
 	})
 
 	var pair TargetMetrics
@@ -128,7 +136,7 @@ func TestFetcher_ConcurrencyLimit(t *testing.T) {
 	targets := make([]endpoints.Target, 0, queueLength)
 	for i := 0; i < queueLength; i++ {
 		addr := url.URL{Scheme: "http", Host: fmt.Sprintf("target%v", i), Path: "/metrics"}
-		targets = append(targets, endpoints.New("", addr, endpoints.Object{}))
+		targets = append(targets, endpoints.Target{URL: addr})
 	}
 	fetcher.Fetch(targets)
 

--- a/internal/integration/fetcher_test.go
+++ b/internal/integration/fetcher_test.go
@@ -28,6 +28,8 @@ const (
 )
 
 func TestFetcher(t *testing.T) {
+	t.Parallel()
+
 	// Given a fetcher
 	fetcher := NewFetcher(fetchDuration, fetchTimeout, workerThreads, "", "", true, queueLength)
 	var invokedURL string
@@ -59,6 +61,8 @@ func TestFetcher(t *testing.T) {
 }
 
 func TestFetcher_Error(t *testing.T) {
+	t.Parallel()
+
 	// Given a fetcher
 	fetcher := NewFetcher(time.Millisecond, fetchTimeout, workerThreads, "", "", true, queueLength)
 
@@ -102,6 +106,8 @@ func TestFetcher_Error(t *testing.T) {
 }
 
 func TestFetcher_ConcurrencyLimit(t *testing.T) {
+	t.Parallel()
+
 	// This test fetches a lot of targets and verifies that no more than "workerThreads" are executed in
 	// parallel
 	parallelTasks := int32(0)
@@ -144,6 +150,8 @@ func TestFetcher_ConcurrencyLimit(t *testing.T) {
 }
 
 func TestConvertPromMetrics(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		target string
 		mfs    prometheus.MetricFamiliesByName
@@ -497,12 +505,20 @@ func TestConvertPromMetrics(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		assert.ElementsMatch(t, test.want, convertPromMetrics(nil, test.target, test.mfs))
+	for i, test := range tests {
+		test := test
+
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			assert.ElementsMatch(t, test.want, convertPromMetrics(nil, test.target, test.mfs))
+		})
 	}
 }
 
 func TestConvertPromMetricsMultiTargetCollisions(t *testing.T) {
+	t.Parallel()
+
 	metric := dto.Metric{
 		Label: []*dto.LabelPair{
 			{

--- a/internal/integration/infra_sdk_emitter_test.go
+++ b/internal/integration/infra_sdk_emitter_test.go
@@ -110,7 +110,7 @@ func TestInfraSdkEmitter_Emit(t *testing.T) {
 func TestInfraSdkEmitter_HistogramEmitsCorrectValue(t *testing.T) {
 	e := NewInfraSdkEmitter(Specs{})
 
-	//TODO find way to emit with different values so we can test the delta calculation on the hist sum
+	// TODO find way to emit with different values so we can test the delta calculation on the hist sum
 	metrics := getHistogram(t)
 
 	rescueStdout := os.Stdout
@@ -121,7 +121,7 @@ func TestInfraSdkEmitter_HistogramEmitsCorrectValue(t *testing.T) {
 	err := e.Emit(metrics)
 	_ = w.Close()
 
-	//then
+	// then
 	assert.NoError(t, err)
 	bytes, _ := ioutil.ReadAll(r)
 	assert.NotEmpty(t, bytes)
@@ -159,7 +159,7 @@ func TestInfraSdkEmitter_HistogramEmitsCorrectValue(t *testing.T) {
 func TestInfraSdkEmitter_SummaryEmitsCorrectValue(t *testing.T) {
 	e := NewInfraSdkEmitter(Specs{})
 
-	//TODO find way to emit with different values so we can test the delta calculation on the hist sum
+	// TODO find way to emit with different values so we can test the delta calculation on the hist sum
 	metrics := getSummary(t)
 
 	rescueStdout := os.Stdout
@@ -170,7 +170,7 @@ func TestInfraSdkEmitter_SummaryEmitsCorrectValue(t *testing.T) {
 	err := e.Emit(metrics)
 	_ = w.Close()
 
-	//then
+	// then
 	assert.NoError(t, err)
 	bytes, _ := ioutil.ReadAll(r)
 	assert.NotEmpty(t, bytes)
@@ -256,7 +256,7 @@ func Test_Emitter_EmitsCorrectEntity(t *testing.T) {
 	err := emitter.Emit(metrics)
 	_ = w.Close()
 
-	//then
+	// then
 	assert.NoError(t, err)
 	bytes, _ := ioutil.ReadAll(r)
 	assert.NotEmpty(t, bytes)
@@ -315,7 +315,6 @@ func Test_ResizeToLimit(t *testing.T) {
 	// should have been resized
 	assert.True(t, resized)
 	assert.Less(t, sb.Len(), original)
-
 }
 
 func getHistogram(t *testing.T) []Metric {
@@ -432,6 +431,7 @@ type metricData struct {
 	Labels    map[string]string   `json:"attributes"`
 	Value     PrometheusMockValue `json:"value,omitempty"`
 }
+
 type PrometheusMockValue struct {
 	SampleCount uint64  `json:"sample_count,omitempty"`
 	SampleSum   float64 `json:"sample_sum,omitempty"`
@@ -447,6 +447,7 @@ type entityDef struct {
 	Type     string         `json:"type"`
 	Metadata entityMetadata `json:"metadata,omitempty"`
 }
+
 type entity struct {
 	Common  common       `json:"common"`
 	Entity  entityDef    `json:"entity,omitempty"`

--- a/internal/integration/infra_sdk_emitter_test.go
+++ b/internal/integration/infra_sdk_emitter_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestInfraSdkEmitter_Name(t *testing.T) {
+	t.Parallel()
+
 	// given
 	e := NewInfraSdkEmitter(Specs{})
 	assert.NotNil(t, e)
@@ -157,6 +159,8 @@ func TestInfraSdkEmitter_HistogramEmitsCorrectValue(t *testing.T) {
 }
 
 func TestInfraSdkEmitter_SummaryEmitsCorrectValue(t *testing.T) {
+	t.Parallel()
+
 	e := NewInfraSdkEmitter(Specs{})
 
 	// TODO find way to emit with different values so we can test the delta calculation on the hist sum
@@ -209,6 +213,7 @@ func TestInfraSdkEmitter_SummaryEmitsCorrectValue(t *testing.T) {
 }
 
 func Test_Emitter_EmitsCorrectEntity(t *testing.T) {
+	t.Parallel()
 
 	specs := Specs{
 		SpecsByName: map[string]SpecDef{
@@ -289,6 +294,7 @@ func Test_Emitter_EmitsCorrectEntity(t *testing.T) {
 }
 
 func Test_ResizeToLimit(t *testing.T) {
+	t.Parallel()
 
 	var sb strings.Builder
 	for i := 0; i < 10; i++ {

--- a/internal/integration/roundtripper_test.go
+++ b/internal/integration/roundtripper_test.go
@@ -13,7 +13,6 @@ type mockedRoundTripper struct {
 }
 
 func (m *mockedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-
 	m.Called(req)
 	return &http.Response{}, nil
 }

--- a/internal/integration/roundtripper_test.go
+++ b/internal/integration/roundtripper_test.go
@@ -18,6 +18,8 @@ func (m *mockedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 func TestRoundTripHeaderDecoration(t *testing.T) {
+	t.Parallel()
+
 	licenseKey := "myLicenseKey"
 	req := &http.Request{Header: make(http.Header)}
 	req.Header.Add("Api-Key", licenseKey)

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestConsolideLabels(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("Auto-decoration isn't used at this moment.")
 	pair := scrapeString(t, prometheusInput)
 	AutoDecorateLabels(&pair)
@@ -86,6 +88,8 @@ func AssertContainsTree(t *testing.T, containing, contained labels.Set) {
 }
 
 func TestMatchingRules(t *testing.T) {
+	t.Parallel()
+
 	entity := scrapeString(t, prometheusInput)
 	dc := MatchingDecorate(&entity, []DecorateRule{
 		{
@@ -120,6 +124,8 @@ func TestMatchingRules(t *testing.T) {
 }
 
 func TestCopyAttributes(t *testing.T) {
+	t.Parallel()
+
 	input := fmt.Sprintf("%s\n%s", prometheusInput,
 		`# HELP some_undecorated_stuff
 # TYPE some_undecorated_stuff gauge
@@ -201,6 +207,8 @@ some_undecorated_stuff{addr="ohai-playground-redis-slave:6379",alias="ohai-playg
 }
 
 func TestCopyAttributes_withPrefix(t *testing.T) {
+	t.Parallel()
+
 	input := fmt.Sprintf("%s\n%s", prometheusInput,
 		`# HELP some_undecorated_stuff
 # TYPE some_undecorated_stuff gauge
@@ -282,6 +290,8 @@ some_undecorated_stuff{addr="ohai-playground-redis-slave:6379",alias="ohai-playg
 }
 
 func TestCopyAttributes_SelectAttributes(t *testing.T) {
+	t.Parallel()
+
 	input := fmt.Sprintf("%s\n%s", prometheusInput,
 		`# HELP some_undecorated_stuff
 # TYPE some_undecorated_stuff gauge
@@ -361,6 +371,8 @@ some_undecorated_stuff{addr="ohai-playground-redis-slave:6379",alias="ohai-playg
 }
 
 func TestDecorate(t *testing.T) {
+	t.Parallel()
+
 	targetURL, _ := url.Parse("https://user:password@newrelic.com")
 	se := []TargetMetrics{{
 		Target: endpoints.Target{
@@ -386,6 +398,8 @@ func TestDecorate(t *testing.T) {
 }
 
 func TestRenameRules(t *testing.T) {
+	t.Parallel()
+
 	entity := scrapeString(t, prometheusInput)
 
 	rules := []RenameRule{
@@ -443,6 +457,8 @@ func TestRenameRules(t *testing.T) {
 }
 
 func TestAddAttributesRules(t *testing.T) {
+	t.Parallel()
+
 	entity := scrapeString(t, prometheusInput)
 	AddAttributes(&entity, []AddAttributesRule{
 		{
@@ -474,6 +490,8 @@ func TestAddAttributesRules(t *testing.T) {
 }
 
 func TestIgnoreRules(t *testing.T) {
+	t.Parallel()
+
 	entity := scrapeString(t, prometheusInput)
 	Filter(&entity, []IgnoreRule{
 		{
@@ -504,6 +522,8 @@ func TestIgnoreRules(t *testing.T) {
 }
 
 func TestIgnoreRules_PrefixesWithExceptions(t *testing.T) {
+	t.Parallel()
+
 	entity := scrapeString(t, prometheusInput)
 	Filter(&entity, []IgnoreRule{
 		{
@@ -536,6 +556,8 @@ func TestIgnoreRules_PrefixesWithExceptions(t *testing.T) {
 }
 
 func TestIgnoreRules_IgnoreAllExceptExceptions(t *testing.T) {
+	t.Parallel()
+
 	entity := scrapeString(t, prometheusInput)
 	Filter(&entity, []IgnoreRule{
 		{

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -383,7 +383,6 @@ func TestDecorate(t *testing.T) {
 
 	assert.Equal(t, se[0].Metrics[0].attributes, labels.Set{"hello": "friend", "bye": "boy", "md1": "v1", "md2": "v2", "attr1": "val1", "scrapedTargetURL": "https://user:xxxxx@newrelic.com"})
 	assert.Equal(t, se[0].Metrics[1].attributes, labels.Set{"hello": "friend", "bye": "boy", "md3": "v3", "md4": "v4", "attr2": "val2", "scrapedTargetURL": "https://user:xxxxx@newrelic.com"})
-
 }
 
 func TestRenameRules(t *testing.T) {

--- a/internal/integration/scrape_test.go
+++ b/internal/integration/scrape_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestScrape(t *testing.T) {
+	t.Parallel()
+
 	// Given a set of fetched metrics
 	input := `# HELP redis_exporter_build_info redis exporter build_info
 # TYPE redis_exporter_build_info gauge

--- a/internal/integration/spec_test.go
+++ b/internal/integration/spec_test.go
@@ -49,9 +49,12 @@ func TestSpecs_getEntity(t *testing.T) {
 					attributes: labels.Set{
 						"database": "test",
 					},
-				}},
-			wantProps: entityNameProps{Service: "ravendb", Name: "database", DisplayName: "Database", Type: "RAVENDB_DATABASE",
-				Labels: []keyValue{{"database", "test"}}},
+				},
+			},
+			wantProps: entityNameProps{
+				Service: "ravendb", Name: "database", DisplayName: "Database", Type: "RAVENDB_DATABASE",
+				Labels: []keyValue{{"database", "test"}},
+			},
 			wantErr: false,
 		},
 		{
@@ -61,7 +64,8 @@ func TestSpecs_getEntity(t *testing.T) {
 				Metric{
 					name:       "ravendb_document_put_bytes_total",
 					attributes: labels.Set{},
-				}},
+				},
+			},
 			wantProps: entityNameProps{Service: "ravendb", Name: "node", DisplayName: "RavenDb Node", Type: "RAVENDB_NODE", Labels: []keyValue{}},
 			wantErr:   false,
 		},
@@ -75,9 +79,12 @@ func TestSpecs_getEntity(t *testing.T) {
 						"dim1": "first",
 						"dim2": "second",
 					},
-				}},
-			wantProps: entityNameProps{Service: "ravendb", Name: "testentity", DisplayName: "testEntity", Type: "RAVENDB_TESTENTITY",
-				Labels: []keyValue{{"dim1", "first"}, {"dim2", "second"}}},
+				},
+			},
+			wantProps: entityNameProps{
+				Service: "ravendb", Name: "testentity", DisplayName: "testEntity", Type: "RAVENDB_TESTENTITY",
+				Labels: []keyValue{{"dim1", "first"}, {"dim2", "second"}},
+			},
 			wantErr: false,
 		},
 		{
@@ -87,9 +94,12 @@ func TestSpecs_getEntity(t *testing.T) {
 				Metric{
 					name:       "redis_commands_duration_seconds_total",
 					attributes: labels.Set{},
-				}},
-			wantProps: entityNameProps{Service: "redis", Name: "instance", DisplayName: "Redis Instance", Type: "REDIS_INSTANCE",
-				Labels: []keyValue{}},
+				},
+			},
+			wantProps: entityNameProps{
+				Service: "redis", Name: "instance", DisplayName: "Redis Instance", Type: "REDIS_INSTANCE",
+				Labels: []keyValue{},
+			},
 			wantErr: false,
 		},
 		{
@@ -99,9 +109,12 @@ func TestSpecs_getEntity(t *testing.T) {
 				Metric{
 					name:       "redis_repl_backlog_is_active",
 					attributes: labels.Set{},
-				}},
-			wantProps: entityNameProps{Service: "redis", Name: "instance", DisplayName: "Redis Instance", Type: "REDIS_INSTANCE",
-				Labels: []keyValue{}},
+				},
+			},
+			wantProps: entityNameProps{
+				Service: "redis", Name: "instance", DisplayName: "Redis Instance", Type: "REDIS_INSTANCE",
+				Labels: []keyValue{},
+			},
 			wantErr: false,
 		},
 		{
@@ -111,9 +124,12 @@ func TestSpecs_getEntity(t *testing.T) {
 				Metric{
 					name:       "redis_metric_bis",
 					attributes: labels.Set{},
-				}},
-			wantProps: entityNameProps{Service: "redis", Name: "testbisredis", DisplayName: "Redis test bis", Type: "REDIS_TESTBISREDIS",
-				Labels: []keyValue{}},
+				},
+			},
+			wantProps: entityNameProps{
+				Service: "redis", Name: "testbisredis", DisplayName: "Redis test bis", Type: "REDIS_TESTBISREDIS",
+				Labels: []keyValue{},
+			},
 			wantErr: false,
 		},
 		{

--- a/internal/integration/spec_test.go
+++ b/internal/integration/spec_test.go
@@ -10,19 +10,25 @@ import (
 )
 
 func TestLoadSpecFilesOk(t *testing.T) {
+	t.Parallel()
+
 	specs, err := LoadSpecFiles("./test/")
 	assert.NoError(t, err)
 	assert.Contains(t, specs.SpecsByName, "ibmmq")
 	assert.Contains(t, specs.SpecsByName, "ravendb")
 	assert.Contains(t, specs.SpecsByName, "redis")
 }
+
 func TestLoadSpecFilesNoFiles(t *testing.T) {
+	t.Parallel()
+
 	specs, err := LoadSpecFiles(".")
 	assert.NoError(t, err)
 	assert.Len(t, specs.SpecsByName, 0)
 }
 
 func TestSpecs_getEntity(t *testing.T) {
+	t.Parallel()
 
 	specs, err := LoadSpecFiles("./test/")
 	assert.NoError(t, err)
@@ -158,7 +164,11 @@ func TestSpecs_getEntity(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			s := &Specs{
 				SpecsByName: tt.fields.SpecsByName,
 			}

--- a/internal/integration/telemetry_sdk_emitter_test.go
+++ b/internal/integration/telemetry_sdk_emitter_test.go
@@ -81,6 +81,8 @@ func BenchmarkTelemetrySDKEmitter(b *testing.B) {
 }
 
 func TestTelemetryEmitterEmit(t *testing.T) {
+	t.Parallel()
+
 	hist, err := newHistogram([]int64{0, 0, 0})
 	if err != nil {
 		t.Fatal(err)
@@ -353,6 +355,8 @@ func TestTelemetryEmitterEmit(t *testing.T) {
 }
 
 func TestTelemetryHarvesterWithTLSConfig(t *testing.T) {
+	t.Parallel()
+
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 	cfg := &telemetry.Config{Client: &http.Client{}}
 	TelemetryHarvesterWithTLSConfig(tlsConfig)(cfg)
@@ -368,6 +372,8 @@ func TestTelemetryHarvesterWithTLSConfig(t *testing.T) {
 }
 
 func TestTelemetryHarvesterWithProxy(t *testing.T) {
+	t.Parallel()
+
 	proxyStr := "http://myproxy:444"
 	proxyURL, err := url.Parse(proxyStr)
 	require.NoError(t, err)

--- a/internal/pkg/endpoints/endpoints.go
+++ b/internal/pkg/endpoints/endpoints.go
@@ -78,12 +78,12 @@ func New(name string, addr url.URL, object Object) Target {
 	}
 }
 
-// EndpointToTarget returns a list of Targets from the provided TargetConfig struct.
+// endpointToTarget returns a list of Targets from the provided TargetConfig struct.
 // The URL processing for every Target follows the next conventions:
 // - if no schema is provided, it assumes http
 // - if no path is provided, it assumes /metrics
 // For example, hostname:8080 will be interpreted as http://hostname:8080/metrics
-func EndpointToTarget(tc TargetConfig) ([]Target, error) {
+func endpointToTarget(tc TargetConfig) ([]Target, error) {
 	targets := make([]Target, 0, len(tc.URLs))
 	for _, URL := range tc.URLs {
 		t, err := urlToTarget(URL, tc.TLSConfig)

--- a/internal/pkg/endpoints/endpoints.go
+++ b/internal/pkg/endpoints/endpoints.go
@@ -1,6 +1,7 @@
-// Package endpoints ...
 // Copyright 2019 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+// Package endpoints ...
 package endpoints
 
 import (

--- a/internal/pkg/endpoints/endpoints.go
+++ b/internal/pkg/endpoints/endpoints.go
@@ -69,15 +69,6 @@ func redactedURLString(u *url.URL) string {
 	return ru.String()
 }
 
-// New returns a Target from the discovered information
-func New(name string, addr url.URL, object Object) Target {
-	return Target{
-		Name:   name,
-		Object: object,
-		URL:    addr,
-	}
-}
-
 // endpointToTarget returns a list of Targets from the provided TargetConfig struct.
 // The URL processing for every Target follows the next conventions:
 // - if no schema is provided, it assumes http

--- a/internal/pkg/endpoints/endpoints_test.go
+++ b/internal/pkg/endpoints/endpoints_test.go
@@ -61,7 +61,7 @@ func TestFromURL(t *testing.T) {
 		t.Run(c.testName, func(t *testing.T) {
 			t.Parallel()
 
-			targets, err := EndpointToTarget(TargetConfig{URLs: []string{c.input}})
+			targets, err := endpointToTarget(TargetConfig{URLs: []string{c.input}})
 			assert.NoError(t, err)
 			assert.Len(t, targets, 1)
 			assert.Equal(t, c.expectedName, targets[0].Name)

--- a/internal/pkg/endpoints/endpoints_test.go
+++ b/internal/pkg/endpoints/endpoints_test.go
@@ -1,5 +1,6 @@
 // Copyright 2019 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package endpoints
 
 import (

--- a/internal/pkg/endpoints/fixed.go
+++ b/internal/pkg/endpoints/fixed.go
@@ -28,7 +28,7 @@ type TLSConfig struct {
 func FixedRetriever(targetCfgs ...TargetConfig) (TargetRetriever, error) {
 	fixed := make([]Target, 0, len(targetCfgs))
 	for _, targetCfg := range targetCfgs {
-		targets, err := EndpointToTarget(targetCfg)
+		targets, err := endpointToTarget(targetCfg)
 		if err != nil {
 			return nil, fmt.Errorf("parsing target %v: %v", targetCfg, err.Error())
 		}

--- a/internal/pkg/endpoints/fixed.go
+++ b/internal/pkg/endpoints/fixed.go
@@ -1,6 +1,6 @@
-// Package endpoints ...
 // Copyright 2019 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package endpoints
 
 import "fmt"

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -1,6 +1,6 @@
-// Package endpoints ...
 // Copyright 2019 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package endpoints
 
 import (

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -135,8 +135,16 @@ func nodeTargets(n *corev1.Node) ([]Target, error) {
 	object := Object{Name: n.Name, Kind: "node", Labels: lbls}
 
 	return []Target{
-		New(n.Name, nodeURL, object),
-		New("cadvisor_"+n.Name, cadvisorURL, object),
+		{
+			Name:   n.Name,
+			URL:    nodeURL,
+			Object: object,
+		},
+		{
+			Name:   "cadvisor_" + n.Name,
+			URL:    cadvisorURL,
+			Object: object,
+		},
 	}, nil
 }
 
@@ -208,8 +216,16 @@ func endpointsTarget(e *corev1.Endpoints, port string, ip string, path string) *
 		klog.WithError(err).WithField("endpoints", e.Name).Errorf("couldn't parse endpoint url, skipping: %s", fullServiceURL)
 		return nil
 	}
-	target := New(e.Name, *addr, Object{Name: e.Name, Kind: "endpoints", Labels: lbls})
-	return &target
+
+	return &Target{
+		Name: e.Name,
+		URL:  *addr,
+		Object: Object{
+			Name:   e.Name,
+			Kind:   "endpoints",
+			Labels: lbls,
+		},
+	}
 }
 
 func serviceTarget(s *corev1.Service, port, path string) *Target {
@@ -227,8 +243,16 @@ func serviceTarget(s *corev1.Service, port, path string) *Target {
 	}
 	lbls["serviceName"] = s.Name
 	lbls["namespaceName"] = s.Namespace
-	target := New(s.Name, *addr, Object{Name: s.Name, Kind: "service", Labels: lbls})
-	return &target
+
+	return &Target{
+		Name: s.Name,
+		URL:  *addr,
+		Object: Object{
+			Name:   s.Name,
+			Kind:   "service",
+			Labels: lbls,
+		},
+	}
 }
 
 // returns all the possible targets for a endpoint (multiple targets per port)
@@ -372,8 +396,16 @@ func podTarget(p *corev1.Pod, port, path string) *Target {
 	lbls["namespaceName"] = p.Namespace
 	lbls["nodeName"] = p.Spec.NodeName
 	lbls["deploymentName"] = getPodDeployment(p)
-	target := New(p.Name, *addr, Object{Name: p.Name, Kind: "pod", Labels: lbls})
-	return &target
+
+	return &Target{
+		Name: p.Name,
+		URL:  *addr,
+		Object: Object{
+			Name:   p.Name,
+			Kind:   "pod",
+			Labels: lbls,
+		},
+	}
 }
 
 func podTargets(p *corev1.Pod) []Target {

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -1,5 +1,6 @@
 // Copyright 2019 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package endpoints
 
 import (

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -706,8 +706,8 @@ func TestWatch_Nodes_NodesWithNoScrapeLabelAreNotBeingScraped(t *testing.T) {
 	}, retry.Timeout(2*time.Second), retry.Delay(100*time.Millisecond))
 }
 
-func newFakeKubernetesTargetRetriever(client *fake.Clientset) *KubernetesTargetRetriever {
-	return &KubernetesTargetRetriever{
+func newFakeKubernetesTargetRetriever(client *fake.Clientset) *kubernetesTargetRetriever {
+	return &kubernetesTargetRetriever{
 		client:             client,
 		targets:            new(sync.Map),
 		scrapeEnabledLabel: "prometheus.io/scrape",

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -184,7 +183,7 @@ func TestWatch_EndpointsModify(t *testing.T) {
 const endpointsName = "my-endpoints"
 
 func populateFakeEndpointsData(clientset *fake.Clientset) error {
-	e := &v1.Endpoints{
+	e := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("niceUid"),
 			Name: endpointsName,
@@ -203,9 +202,9 @@ func populateFakeEndpointsData(clientset *fake.Clientset) error {
 				"app":                  "my-app",
 			},
 		},
-		Subsets: []v1.EndpointSubset{
+		Subsets: []corev1.EndpointSubset{
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []corev1.EndpointAddress{
 					{
 						IP: "1.2.3.4",
 					},
@@ -213,42 +212,42 @@ func populateFakeEndpointsData(clientset *fake.Clientset) error {
 						IP: "5.6.7.8",
 					},
 				},
-				NotReadyAddresses: []v1.EndpointAddress{
+				NotReadyAddresses: []corev1.EndpointAddress{
 					{
 						IP: "10.20.30.40",
 					},
 				},
-				Ports: []v1.EndpointPort{
+				Ports: []corev1.EndpointPort{
 					{
 						Port:     1,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 					{
 						Port:     2,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 				},
 			},
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []corev1.EndpointAddress{
 					{
 						IP: "1.2.3.4",
 					},
 				},
-				Ports: []v1.EndpointPort{
+				Ports: []corev1.EndpointPort{
 					{
 						Port:     3,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 					{
 						Port:     4,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 				},
 			},
 		},
 	}
-	s := &v1.Service{
+	s := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: endpointsName,
 			Labels: map[string]string{
@@ -276,7 +275,7 @@ func populateFakeEndpointsData(clientset *fake.Clientset) error {
 }
 
 func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
-	e := &v1.Endpoints{
+	e := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("niceUid"),
 			Name: endpointsName,
@@ -295,9 +294,9 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 				"app":                  "my-app",
 			},
 		},
-		Subsets: []v1.EndpointSubset{
+		Subsets: []corev1.EndpointSubset{
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []corev1.EndpointAddress{
 					{
 						IP: "1.2.3.4",
 					},
@@ -305,42 +304,42 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 						IP: "5.6.7.8",
 					},
 				},
-				NotReadyAddresses: []v1.EndpointAddress{
+				NotReadyAddresses: []corev1.EndpointAddress{
 					{
 						IP: "10.20.30.40",
 					},
 				},
-				Ports: []v1.EndpointPort{
+				Ports: []corev1.EndpointPort{
 					{
 						Port:     1,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 					{
 						Port:     2,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 				},
 			},
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []corev1.EndpointAddress{
 					{
 						IP: "1.2.3.4",
 					},
 				},
-				Ports: []v1.EndpointPort{
+				Ports: []corev1.EndpointPort{
 					{
 						Port:     3,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 					{
 						Port:     4,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 				},
 			},
 		},
 	}
-	s := &v1.Service{
+	s := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: endpointsName,
 			Labels: map[string]string{
@@ -370,14 +369,14 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 }
 
 func populateFakeEndpointsDataWithModify(clientset *fake.Clientset) error {
-	e := &v1.Endpoints{
+	e := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("niceUid"),
 			Name: endpointsName,
 		},
-		Subsets: []v1.EndpointSubset{
+		Subsets: []corev1.EndpointSubset{
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []corev1.EndpointAddress{
 					{
 						IP: "1.2.3.4",
 					},
@@ -385,43 +384,43 @@ func populateFakeEndpointsDataWithModify(clientset *fake.Clientset) error {
 						IP: "5.6.7.8",
 					},
 				},
-				NotReadyAddresses: []v1.EndpointAddress{
+				NotReadyAddresses: []corev1.EndpointAddress{
 					{
 						IP: "10.20.30.40",
 					},
 				},
-				Ports: []v1.EndpointPort{
+				Ports: []corev1.EndpointPort{
 					{
 						Port:     1,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 					{
 						Port:     2,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 				},
 			},
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []corev1.EndpointAddress{
 					{
 						IP: "1.2.3.4",
 					},
 				},
-				Ports: []v1.EndpointPort{
+				Ports: []corev1.EndpointPort{
 					{
 						Port:     3,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 					{
 						Port:     4,
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 					},
 				},
 			},
 		},
 	}
 
-	s := &v1.Service{
+	s := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: endpointsName,
 			Labels: map[string]string{
@@ -446,7 +445,7 @@ func populateFakeEndpointsDataWithModify(clientset *fake.Clientset) error {
 
 	e.Subsets[0].NotReadyAddresses = nil
 	addr := e.Subsets[0].Addresses
-	e.Subsets[0].Addresses = append(addr, v1.EndpointAddress{IP: "10.20.30.40"})
+	e.Subsets[0].Addresses = append(addr, corev1.EndpointAddress{IP: "10.20.30.40"})
 	_, err = clientset.CoreV1().Endpoints("test-ns").Update(context.TODO(), e, metav1.UpdateOptions{})
 	if err != nil {
 		return err
@@ -716,18 +715,18 @@ func newFakeKubernetesTargetRetriever(client *fake.Clientset) *KubernetesTargetR
 	}
 }
 
-func fakeNodeData() []*v1.Node {
-	return []*v1.Node{
+func fakeNodeData() []*corev1.Node {
+	return []*corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				UID:    types.UID("zetano"),
 				Name:   "my-node",
 				Labels: map[string]string{},
 			},
-			Status: v1.NodeStatus{
-				Addresses: []v1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
-						Type:    v1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 						Address: "127.0.0.1",
 					},
 				},
@@ -739,10 +738,10 @@ func fakeNodeData() []*v1.Node {
 				Name:   "my-node2",
 				Labels: map[string]string{},
 			},
-			Status: v1.NodeStatus{
-				Addresses: []v1.NodeAddress{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
 					{
-						Type:    v1.NodeInternalIP,
+						Type:    corev1.NodeInternalIP,
 						Address: "127.0.0.2",
 					},
 				},
@@ -766,7 +765,7 @@ func populateFakeNodeData(clientset *fake.Clientset) error {
 }
 
 func populateFakePodDataModify(clientset *fake.Clientset) error {
-	p := &v1.Pod{
+	p := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("mengano"),
 			Name: "my-pod",
@@ -775,22 +774,22 @@ func populateFakePodDataModify(clientset *fake.Clientset) error {
 				"app":                  "pod-my-app",
 			},
 		},
-		Spec: v1.PodSpec{Containers: []v1.Container{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http-metrics",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: 8080,
 					},
 				},
 			},
 		}},
-		Status: v1.PodStatus{
+		Status: corev1.PodStatus{
 			PodIP: "10.10.10.1",
 		},
 	}
-	p2 := &v1.Pod{
+	p2 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("zutano"),
 			Name: "my-pod-2",
@@ -799,23 +798,23 @@ func populateFakePodDataModify(clientset *fake.Clientset) error {
 				"app":                  "pod-my-app-2",
 			},
 		},
-		Spec: v1.PodSpec{Containers: []v1.Container{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http-metrics",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: 8080,
 					},
 				},
 			},
 		}},
-		Status: v1.PodStatus{
+		Status: corev1.PodStatus{
 			PodIP: "10.10.10.2",
 		},
 	}
 
-	p3 := &v1.Pod{
+	p3 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("pepito"),
 			Name: "my-pod-3",
@@ -824,18 +823,18 @@ func populateFakePodDataModify(clientset *fake.Clientset) error {
 				"app":                  "pod-my-app-3",
 			},
 		},
-		Spec: v1.PodSpec{Containers: []v1.Container{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http-metrics",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: 8080,
 					},
 				},
 			},
 		}},
-		Status: v1.PodStatus{
+		Status: corev1.PodStatus{
 			PodIP: "10.10.10.3",
 		},
 	}
@@ -878,7 +877,7 @@ func populateFakePodDataModify(clientset *fake.Clientset) error {
 }
 
 func populateFakePodData(clientset *fake.Clientset) error {
-	p := &v1.Pod{
+	p := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("mengano"),
 			Name: "my-pod",
@@ -888,23 +887,23 @@ func populateFakePodData(clientset *fake.Clientset) error {
 				"app":                  "pod-my-app",
 			},
 		},
-		Spec: v1.PodSpec{Containers: []v1.Container{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http-metrics",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: 8080,
 					},
 				},
 			},
 		}},
-		Status: v1.PodStatus{
+		Status: corev1.PodStatus{
 			PodIP: "10.10.10.1",
 		},
 	}
 
-	p2 := &v1.Pod{
+	p2 := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("zutano"),
 			Name: "my-pod-2",
@@ -913,18 +912,18 @@ func populateFakePodData(clientset *fake.Clientset) error {
 				"app":                  "pod-my-app-2",
 			},
 		},
-		Spec: v1.PodSpec{Containers: []v1.Container{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http-metrics",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: 8080,
 					},
 				},
 			},
 		}},
-		Status: v1.PodStatus{
+		Status: corev1.PodStatus{
 			PodIP: "10.10.10.2",
 		},
 	}
@@ -942,7 +941,7 @@ func populateFakePodData(clientset *fake.Clientset) error {
 }
 
 func populateFakeServiceData(clientset *fake.Clientset) error {
-	s := &v1.Service{
+	s := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("niceUid"),
 			Name: "my-service",
@@ -952,17 +951,17 @@ func populateFakeServiceData(clientset *fake.Clientset) error {
 				"app":                  "my-app",
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
 				{
 					Name:     "http-metrics",
-					Protocol: v1.ProtocolTCP,
+					Protocol: corev1.ProtocolTCP,
 					Port:     8080,
 				},
 			},
 		},
 	}
-	s2 := &v1.Service{
+	s2 := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:    types.UID("notNiceUid"),
 			Name:   "my-service-no-scrapeable",
@@ -986,7 +985,7 @@ func TestPodTargetsPortAnnotationsOverrideLabels(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
@@ -999,12 +998,12 @@ func TestPodTargetsPortAnnotationsOverrideLabels(t *testing.T) {
 					"prometheus.io/port": "80",
 				},
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1017,7 +1016,7 @@ func TestPodTargetsPortAnnotationsOverrideLabels(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1050,17 +1049,17 @@ func TestPodTargetsNoPort(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1073,7 +1072,7 @@ func TestPodTargetsNoPort(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1123,7 +1122,7 @@ func TestPodTargetsPortAnnotation(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
@@ -1132,12 +1131,12 @@ func TestPodTargetsPortAnnotation(t *testing.T) {
 					"prometheus.io/port":   "8080",
 				},
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1150,7 +1149,7 @@ func TestPodTargetsPortAnnotation(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1182,7 +1181,7 @@ func TestPodTargetsInvalidURL(t *testing.T) {
 
 	assert.Empty(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
@@ -1191,12 +1190,12 @@ func TestPodTargetsInvalidURL(t *testing.T) {
 					"prometheus.io/port":   "foobar",
 				},
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1209,7 +1208,7 @@ func TestPodTargetsInvalidURL(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1221,7 +1220,7 @@ func TestPodTargetsPortLabels(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
@@ -1230,12 +1229,12 @@ func TestPodTargetsPortLabels(t *testing.T) {
 					"prometheus.io/port":   "8080",
 				},
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1248,7 +1247,7 @@ func TestPodTargetsPortLabels(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1282,7 +1281,7 @@ func TestServiceTargetsPortAnnotationsOverrideLabels(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
@@ -1295,8 +1294,8 @@ func TestServiceTargetsPortAnnotationsOverrideLabels(t *testing.T) {
 					"prometheus.io/port": "80",
 				},
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-app",
 						Port: 80,
@@ -1335,7 +1334,7 @@ func TestServiceTargetsPortAnnotation(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
@@ -1344,8 +1343,8 @@ func TestServiceTargetsPortAnnotation(t *testing.T) {
 					"prometheus.io/port":   "8080",
 				},
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-app",
 						Port: 80,
@@ -1383,7 +1382,7 @@ func TestServiceTargetsInvalidURL(t *testing.T) {
 
 	assert.Empty(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
@@ -1392,8 +1391,8 @@ func TestServiceTargetsInvalidURL(t *testing.T) {
 					"prometheus.io/port":   "foobar",
 				},
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-app",
 						Port: 80,
@@ -1413,13 +1412,13 @@ func TestServiceTargetsNoPort(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-app",
 						Port: 80,
@@ -1473,7 +1472,7 @@ func TestServiceTargetsPortLabel(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
@@ -1482,8 +1481,8 @@ func TestServiceTargetsPortLabel(t *testing.T) {
 					"prometheus.io/port":   "8080",
 				},
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-app",
 						Port: 80,
@@ -1527,7 +1526,7 @@ func TestProcessEventPodWithoutPodIP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("seed"),
 			Name: "test-pod",
@@ -1535,12 +1534,12 @@ func TestProcessEventPodWithoutPodIP(t *testing.T) {
 				"prometheus.io/scrape": "true",
 			},
 		},
-		Spec: v1.PodSpec{Containers: []v1.Container{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http-metrics",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: 8080,
 					},
 				},
@@ -1555,7 +1554,7 @@ func TestProcessEventPodWithoutPodIP(t *testing.T) {
 	assert.Nil(t, actual)
 
 	// The pod has been updated, and has a PodIP assigned
-	pod.Status = v1.PodStatus{PodIP: "10.10.10.10"}
+	pod.Status = corev1.PodStatus{PodIP: "10.10.10.10"}
 
 	// We process the message again, and check if it now successfully caches the Pod
 	event = watch.Event{Type: watch.Modified, Object: pod}
@@ -1574,7 +1573,7 @@ func TestProcessEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  types.UID("seed"),
 			Name: "test-pod",
@@ -1582,18 +1581,18 @@ func TestProcessEvent(t *testing.T) {
 				"prometheus.io/scrape": "true",
 			},
 		},
-		Spec: v1.PodSpec{Containers: []v1.Container{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{
 			{
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http-metrics",
-						Protocol:      v1.ProtocolTCP,
+						Protocol:      corev1.ProtocolTCP,
 						ContainerPort: 8080,
 					},
 				},
 			},
 		}},
-		Status: v1.PodStatus{PodIP: "10.10.10.10"},
+		Status: corev1.PodStatus{PodIP: "10.10.10.10"},
 	}
 
 	// Add the event.
@@ -1657,7 +1656,7 @@ func TestPodTargetsPathAnnotationsOverrideLabels(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
@@ -1669,12 +1668,12 @@ func TestPodTargetsPathAnnotationsOverrideLabels(t *testing.T) {
 					"prometheus.io/path": "/metrics/0",
 				},
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1683,7 +1682,7 @@ func TestPodTargetsPathAnnotationsOverrideLabels(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1716,7 +1715,7 @@ func TestPodTargetsPathAnnotations(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
@@ -1724,12 +1723,12 @@ func TestPodTargetsPathAnnotations(t *testing.T) {
 					"prometheus.io/path": "/metrics/1",
 				},
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1738,7 +1737,7 @@ func TestPodTargetsPathAnnotations(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1770,7 +1769,7 @@ func TestPodTargetsPathLabel(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		podTargets(&apiv1.Pod{
+		podTargets(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-pod",
 				Namespace: "test-ns",
@@ -1778,12 +1777,12 @@ func TestPodTargetsPathLabel(t *testing.T) {
 					"prometheus.io/path": "/metrics/1",
 				},
 			},
-			Spec: apiv1.PodSpec{
+			Spec: corev1.PodSpec{
 				NodeName: "node-a",
-				Containers: []apiv1.Container{
+				Containers: []corev1.Container{
 					{
 						Name: "app",
-						Ports: []apiv1.ContainerPort{
+						Ports: []corev1.ContainerPort{
 							{
 								Name:          "http-app",
 								ContainerPort: 80,
@@ -1792,7 +1791,7 @@ func TestPodTargetsPathLabel(t *testing.T) {
 					},
 				},
 			},
-			Status: apiv1.PodStatus{
+			Status: corev1.PodStatus{
 				PodIP: "10.0.0.1",
 			},
 		}),
@@ -1825,7 +1824,7 @@ func TestServiceTargetsPathAnnotationsOverrideLabels(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
@@ -1837,8 +1836,8 @@ func TestServiceTargetsPathAnnotationsOverrideLabels(t *testing.T) {
 					"prometheus.io/path": "/metrics/0",
 				},
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-metrics",
 						Port: 8080,
@@ -1873,7 +1872,7 @@ func TestServiceTargetsPathAnnotations(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
@@ -1881,8 +1880,8 @@ func TestServiceTargetsPathAnnotations(t *testing.T) {
 					"prometheus.io/path": "/metrics/1",
 				},
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-metrics",
 						Port: 8080,
@@ -1916,7 +1915,7 @@ func TestServiceTargetsPathLabel(t *testing.T) {
 
 	assert.ElementsMatch(
 		t,
-		serviceTargets(&apiv1.Service{
+		serviceTargets(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-service",
 				Namespace: "test-ns",
@@ -1924,8 +1923,8 @@ func TestServiceTargetsPathLabel(t *testing.T) {
 					"prometheus.io/path": "/metrics/1",
 				},
 			},
-			Spec: apiv1.ServiceSpec{
-				Ports: []apiv1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
 					{
 						Name: "http-metrics",
 						Port: 8080,

--- a/internal/pkg/endpoints/metrics.go
+++ b/internal/pkg/endpoints/metrics.go
@@ -5,18 +5,16 @@ package endpoints
 
 import "github.com/prometheus/client_golang/prometheus"
 
-var (
-	listTargetsDurationByKind = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "nr_stats",
-		Subsystem: "integration",
-		Name:      "list_targets_duration_by_kind",
-		Help:      "The total time in seconds to get the list of targets for a resource kind",
+var listTargetsDurationByKind = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "nr_stats",
+	Subsystem: "integration",
+	Name:      "list_targets_duration_by_kind",
+	Help:      "The total time in seconds to get the list of targets for a resource kind",
+},
+	[]string{
+		"retriever",
+		"kind",
 	},
-		[]string{
-			"retriever",
-			"kind",
-		},
-	)
 )
 
 func init() {

--- a/internal/pkg/endpoints/metrics.go
+++ b/internal/pkg/endpoints/metrics.go
@@ -1,6 +1,6 @@
-// Package endpoints ...
 // Copyright 2019 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package endpoints
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/internal/pkg/endpoints/self.go
+++ b/internal/pkg/endpoints/self.go
@@ -26,7 +26,7 @@ func newSelfTargetConfig() TargetConfig {
 // SelfRetriever creates a TargetRetriver that returns the targets belonging
 // to nri-prometheus.
 func SelfRetriever() (TargetRetriever, error) {
-	targets, err := EndpointToTarget(newSelfTargetConfig())
+	targets, err := endpointToTarget(newSelfTargetConfig())
 	if err != nil {
 		return nil, fmt.Errorf("parsing target %v: %v", selfDescription, err.Error())
 	}

--- a/internal/pkg/endpoints/self.go
+++ b/internal/pkg/endpoints/self.go
@@ -1,6 +1,6 @@
-// Package endpoints ...
 // Copyright 2019 New Relic Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 package endpoints
 
 import (

--- a/internal/pkg/endpoints/self.go
+++ b/internal/pkg/endpoints/self.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 )
 
-const selfEndpoint = "localhost:8080"
-const selfDescription = "nri-prometheus"
+const (
+	selfEndpoint    = "localhost:8080"
+	selfDescription = "nri-prometheus"
+)
 
 type selfRetriever struct {
 	targets []Target


### PR DESCRIPTION
This PR brings various improvements to `internal/pkg/endpoints` and `internal/integration` packages like better formatting, imports, parallel tests. There is no functional changes, but I believe those changes should make code easier to read and understand.

There are some changes to exported types to simplify the APIs of internal packages.