### PR TITLE
feat(infra_emitter): add common attributes

### DIFF
--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -200,20 +200,6 @@ func RunOnceWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 	}
 	retrievers = append(retrievers, fixedRetriever)
 
-	defaultTransformations := integration.ProcessingRule{
-		Description: "Default transformation rules",
-		AddAttributes: []integration.AddAttributesRule{
-			{
-				MetricPrefix: "",
-				Attributes: map[string]interface{}{
-					"integrationVersion": integration.Version,
-					"integrationName":    integration.Name,
-				},
-			},
-		},
-	}
-	processingRules := append(cfg.ProcessingRules, defaultTransformations)
-
 	scrapeDuration, err := time.ParseDuration(cfg.ScrapeDuration)
 	if err != nil {
 		return fmt.Errorf(
@@ -227,7 +213,7 @@ func RunOnceWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 	integration.ExecuteOnce(
 		retrievers,
 		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
-		integration.RuleProcessor(processingRules, queueLength),
+		integration.RuleProcessor(cfg.ProcessingRules, queueLength),
 		emitters)
 
 	return nil

--- a/internal/integration/fetcher.go
+++ b/internal/integration/fetcher.go
@@ -365,6 +365,7 @@ func convertPromMetrics(log *logrus.Entry, targetName string, mfs prometheus.Met
 			for _, l := range m.GetLabel() {
 				attrs[l.GetName()] = l.GetValue()
 			}
+			// nrMetricType and promMetricType attributes were created as a debugging tool, because some prometheus metric types weren't supported natively by NR.
 			attrs["nrMetricType"] = string(nrType)
 			attrs["promMetricType"] = mtype
 			metrics = append(

--- a/internal/integration/infra_sdk_emitter_test.go
+++ b/internal/integration/infra_sdk_emitter_test.go
@@ -7,10 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	sdk "github.com/newrelic/infra-integrations-sdk/v4/integration"
 	"github.com/newrelic/nri-prometheus/internal/synthesis"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInfraSdkEmitter_Name(t *testing.T) {
@@ -342,43 +340,53 @@ redis_foo_test{hostname="localhost",env="dev",uniquelabel="test"} 3
 	// print json for debug purposes
 	t.Log(string(bytes))
 
-	var result sdk.Integration
-	// metrics fails to unmarshall since Entity.data.metrics is an interface.
+	var result Result
 	assert.Error(t, json.Unmarshal(bytes, &result))
 
 	assert.Len(t, result.Entities, 4)
-	e, ok := result.FindEntity("REDIS:" + metrics.Target.Name)
+	e, ok := result.findEntity("REDIS:" + metrics.Target.Name)
 	assert.True(t, ok)
 	assert.Len(t, e.Metrics, 3)
-	assert.Contains(t, e.Metadata.GetMetadata("tags.version"), "v1.10.0")
-	assert.Contains(t, e.Metadata.GetMetadata("tags.env"), "dev")
-	assert.Contains(t, e.Metadata.GetMetadata("tags.uniquelabel"), "test")
-	assert.Contains(t, e.CommonDimensions, "targetName")
 
-	e, ok = result.FindEntity("REDIS_FOO:" + metrics.Target.Name)
-	assert.True(t, ok)
-	assert.Len(t, e.Metrics, 1)
-	assert.Nil(t, e.Metadata.GetMetadata("tags.version"))
-	assert.Contains(t, e.Metadata.GetMetadata("tags.env"), "dev")
-	assert.Contains(t, e.Metadata.GetMetadata("tags.uniquelabel"), "test")
-
-	e, ok = result.FindEntity("MULTI:" + metrics.Target.Name)
-	assert.True(t, ok)
-	assert.Len(t, e.Metrics, 2)
-	assert.Contains(t, e.Metadata.GetMetadata("tags.env"), "dev")
-	assert.Contains(t, e.Metadata.GetMetadata("tags.foo"), "foo")
-	assert.Contains(t, e.Metadata.GetMetadata("tags.bar"), "bar")
-
-	var hostEntity *sdk.Entity
-	for _, e := range result.Entities {
-		if e.Metadata == nil {
-			hostEntity = e
-			break
+	// Metrics does not contain common nor removed attributes.
+	for _, m := range e.Metrics {
+		for k := range commonAttributes {
+			_, ok := m.Labels[k]
+			assert.False(t, ok)
+		}
+		for k := range removedAttributes {
+			_, ok := m.Labels[k]
+			assert.False(t, ok)
 		}
 	}
-	require.NotNil(t, hostEntity)
-	assert.Len(t, hostEntity.Metrics, 2)
-	assert.Contains(t, hostEntity.CommonDimensions, "targetName")
+
+	em := e.EntityDef.Metadata
+	assert.Contains(t, em["tags.version"], "v1.10.0")
+	assert.Contains(t, em["tags.env"], "dev")
+	assert.Contains(t, em["tags.uniquelabel"], "test")
+	assert.Contains(t, e.Common, "targetName")
+
+	e, ok = result.findEntity("REDIS_FOO:" + metrics.Target.Name)
+	assert.True(t, ok)
+	assert.Len(t, e.Metrics, 1)
+	em = e.EntityDef.Metadata
+	_, ok = em["tags.version"]
+	assert.False(t, ok)
+	assert.Contains(t, em["tags.env"], "dev")
+	assert.Contains(t, em["tags.uniquelabel"], "test")
+
+	e, ok = result.findEntity("MULTI:" + metrics.Target.Name)
+	assert.True(t, ok)
+	assert.Len(t, e.Metrics, 2)
+	em = e.EntityDef.Metadata
+	assert.Contains(t, em["tags.env"], "dev")
+	assert.Contains(t, em["tags.foo"], "foo")
+	assert.Contains(t, em["tags.bar"], "bar")
+
+	e, ok = result.findEntity("")
+	assert.True(t, ok)
+	assert.Len(t, e.Metrics, 2)
+	assert.Contains(t, e.Common["targetName"], metrics.Target.Name)
 }
 
 func Test_ResizeToLimit(t *testing.T) {
@@ -536,20 +544,24 @@ type PrometheusMockValue struct {
 	Quantiles []quant   `json:"quantiles,omitempty"`
 }
 
-type entityDef struct {
-	Name     string         `json:"name"`
-	Type     string         `json:"type"`
-	Metadata entityMetadata `json:"metadata,omitempty"`
-}
-
 type entity struct {
-	Common  common       `json:"common"`
-	Entity  entityDef    `json:"entity,omitempty"`
-	Metrics []metricData `json:"metrics"`
+	Common    common         `json:"common"`
+	EntityDef entityMetadata `json:"entity,omitempty"`
+	Metrics   []metricData   `json:"metrics"`
 }
 
 type Result struct {
 	ProtocolVersion string   `json:"protocol_version"`
 	Metadata        metadata `json:"integration"`
 	Entities        []entity `json:"data"`
+}
+
+func (r Result) findEntity(name string) (entity, bool) {
+	for _, e := range r.Entities {
+		if e.EntityDef.Name == name {
+			return e, true
+		}
+	}
+
+	return entity{}, false
 }

--- a/internal/integration/infra_sdk_emitter_test.go
+++ b/internal/integration/infra_sdk_emitter_test.go
@@ -353,6 +353,7 @@ redis_foo_test{hostname="localhost",env="dev",uniquelabel="test"} 3
 	assert.Contains(t, e.Metadata.GetMetadata("tags.version"), "v1.10.0")
 	assert.Contains(t, e.Metadata.GetMetadata("tags.env"), "dev")
 	assert.Contains(t, e.Metadata.GetMetadata("tags.uniquelabel"), "test")
+	assert.Contains(t, e.CommonDimensions, "targetName")
 
 	e, ok = result.FindEntity("REDIS_FOO:" + metrics.Target.Name)
 	assert.True(t, ok)
@@ -377,6 +378,7 @@ redis_foo_test{hostname="localhost",env="dev",uniquelabel="test"} 3
 	}
 	require.NotNil(t, hostEntity)
 	assert.Len(t, hostEntity.Metrics, 2)
+	assert.Contains(t, hostEntity.CommonDimensions, "targetName")
 }
 
 func Test_ResizeToLimit(t *testing.T) {
@@ -505,7 +507,7 @@ type entityMetadata struct {
 	Metadata    map[string]interface{} `json:"metadata"`
 }
 
-type common struct{}
+type common map[string]string
 
 type quant struct {
 	Quantile *float64 `json:"quantile,omitempty"`


### PR DESCRIPTION
This PR fixes https://github.com/newrelic/newrelic-coreint/issues/109

It also removes the following attributes from the metrics since they are not needed on the sdkV4 protocol:
- `nrMetricType`
- `promMetricType`
- `integrationVersion` this was replaced by `instrumentation.version` populated in the Agent from the Integration Metadata
- `integrationName`  this was replaced by `instrumentation.name` populated in the Agent from the Integration Metadata