### PR TITLE
[CI/CD] publish latest and latest-pre image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,6 +151,11 @@ docker_manifests:
   - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-amd64'
   - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-arm64'
   - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-arm'
+- name_template: newrelic/nri-prometheus:lastest{{ .Env.TAG_SUFFIX }}
+  image_templates:
+    - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-amd64'
+    - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-arm64'
+    - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-arm'
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -151,7 +151,7 @@ docker_manifests:
   - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-amd64'
   - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-arm64'
   - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-arm'
-- name_template: newrelic/nri-prometheus:lastest{{ .Env.TAG_SUFFIX }}
+- name_template: newrelic/nri-prometheus:latest{{ .Env.TAG_SUFFIX }}
   image_templates:
     - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-amd64'
     - 'newrelic/nri-prometheus:{{ .Version }}{{ .Env.TAG_SUFFIX }}-arm64'


### PR DESCRIPTION
In order to support the canary reroller we need latest image.

After this change we are going to have two images created: 
 - nri-prometheus:latest for the stable channel
 - nri-promatheus:latest-pre for the unstable channel