### PR TITLE
fix(infraSDK): using cumulativeCount to report deltas

### DIFF
--- a/internal/integration/infra_sdk_emitter.go
+++ b/internal/integration/infra_sdk_emitter.go
@@ -85,7 +85,7 @@ func (e *InfraSdkEmitter) Emit(metrics []Metric) error {
 			err = e.emitGauge(i, me, now)
 			break
 		case metricType_COUNTER:
-			err = e.emitCounter(i, me, now)
+			err = e.emitCumulativeCounter(i, me, now)
 			break
 		case metricType_SUMMARY:
 			err = e.emitSummary(i, me, now)
@@ -114,8 +114,10 @@ func (e *InfraSdkEmitter) emitGauge(i *sdk.Integration, metric Metric, timestamp
 	return e.addMetricToEntity(i, metric, m)
 }
 
-func (e *InfraSdkEmitter) emitCounter(i *sdk.Integration, metric Metric, timestamp time.Time) error {
-	m, err := sdk.Count(timestamp, metric.name, metric.value.(float64))
+// emitCumulativeCounter calls CumulativeCount that instead of Count, in this way in the agent the delta will be
+// computed and reported instead of the absolute value
+func (e *InfraSdkEmitter) emitCumulativeCounter(i *sdk.Integration, metric Metric, timestamp time.Time) error {
+	m, err := sdk.CumulativeCount(timestamp, metric.name, metric.value.(float64))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Moving to cumulative count, in the agent the delta is computed:

```go
		case "cumulative-count":
			c = Conversion{toTelemetry: Count{calculate: &Cumulative{get: s.calculator.delta.CountMetric}}}

	//GetCumulativeCount creates a count metric from the difference between the values and
	//timestamps of multiple calls.  If this is the first time the name/attributes
	//combination has been seen then the `valid` return value will be false.
```