### PR TITLE
allow metric filtering by suffix

### DIFF
--- a/internal/integration/fetcher.go
+++ b/internal/integration/fetcher.go
@@ -26,7 +26,7 @@ import (
 
 // Fetcher provides fetching functionality to a set of Prometheus endpoints
 type Fetcher interface {
-	// Fetcher fetches data from a set of Prometheus /metrics endpoints. It ignores failed endpoints.
+	// Fetch fetches data from a set of Prometheus /metrics endpoints. It ignores failed endpoints.
 	// It returns each data entry from a channel, assuming this function may run in background.
 	Fetch(t []endpoints.Target) <-chan TargetMetrics
 }

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -439,13 +439,16 @@ func TestIgnoreRules(t *testing.T) {
 		{
 			Prefixes: []string{"redis_instance"},
 		},
+		{
+			Suffixes: []string{"_info"},
+		},
 	})
 
 	actual := map[string]interface{}{}
 	for _, metric := range entity.Metrics {
 		switch metric.name {
 		case "redis_exporter_build_info":
-			actual[metric.name] = 1
+			require.Fail(t, "redis_exporter_build_info must have been filtered")
 		case "redis_instantaneous_input_kbps":
 			actual[metric.name] = 1
 		case "redis_exporter_scrapes_total":
@@ -456,7 +459,6 @@ func TestIgnoreRules(t *testing.T) {
 			require.Fail(t, "unexpected metric", "%#v", metric)
 		}
 	}
-	assert.Contains(t, actual, "redis_exporter_build_info")
 	assert.Contains(t, actual, "redis_instantaneous_input_kbps")
 }
 
@@ -491,6 +493,40 @@ func TestIgnoreRules_PrefixesWithExceptions(t *testing.T) {
 
 	assert.Len(t, actual, 2)
 	assert.Contains(t, actual, "redis_exporter_build_info")
+	assert.Contains(t, actual, "redis_instance_info")
+}
+
+func TestIgnoreRules_SuffixesWithExceptions(t *testing.T) {
+	t.Parallel()
+
+	entity := scrapeString(t, prometheusInput)
+	filter(&entity, []IgnoreRule{
+		{
+			Suffixes: []string{"exporter_scrapes_total"},
+		},
+		{
+			Suffixes: []string{"_info"}, Except: []string{"redis_instance_info"},
+		},
+	})
+
+	actual := map[string]interface{}{}
+	for _, metric := range entity.Metrics {
+		switch metric.name {
+		case "redis_instantaneous_input_kbps":
+			actual[metric.name] = 1
+		case "redis_exporter_build_info":
+			require.Fail(t, "redis_exporter_build_info must have been filtered")
+		case "redis_exporter_scrapes_total":
+			require.Fail(t, "redis_exporter_scrapes_total must have been filtered")
+		case "redis_instance_info":
+			actual[metric.name] = 1
+		default:
+			require.Fail(t, "unexpected metric", "%#v", metric)
+		}
+	}
+
+	assert.Len(t, actual, 2)
+	assert.Contains(t, actual, "redis_instantaneous_input_kbps")
 	assert.Contains(t, actual, "redis_instance_info")
 }
 


### PR DESCRIPTION
allow metric filtering by suffix
Ex.
```
transformations:
  - description: "General processing rules"
    ignore_metrics:
      - suffixes:
        - "_bucket"
```

The use case is the ability to ignore histograms which generate a large number of (unused) metrics.
```
# HELP argocd_redis_request_duration Redis requests duration.
# TYPE argocd_redis_request_duration histogram
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.01"} 2.791635e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.05"} 3.347797e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.1"} 3.582787e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.25"} 3.609236e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.5"} 3.609581e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="1"} 3.609594e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="+Inf"} 3.609602e+06
argocd_redis_request_duration_sum{hostname="argocd-application-controller-1",initiator="argocd-application-controller"} 41456.31533212083
argocd_redis_request_duration_count{hostname="argocd-application-controller-1",initiator="argocd-application-controller"} 3.609602e+06
```

In the above case we want to ignore `argocd_redis_request_duration_bucket` but keep metrics for `argocd_redis_request_duration_sum` and `argocd_redis_request_duration_count`

Signed-off-by: smcavallo <smcavallo@hotmail.com>