### PR TITLE
Ignore metrics by type

### DIFF
--- a/internal/integration/fetcher.go
+++ b/internal/integration/fetcher.go
@@ -26,7 +26,7 @@ import (
 
 // Fetcher provides fetching functionality to a set of Prometheus endpoints
 type Fetcher interface {
-	// Fetcher fetches data from a set of Prometheus /metrics endpoints. It ignores failed endpoints.
+	// Fetch fetches data from a set of Prometheus /metrics endpoints. It ignores failed endpoints.
 	// It returns each data entry from a channel, assuming this function may run in background.
 	Fetch(t []endpoints.Target) <-chan TargetMetrics
 }

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -494,6 +494,37 @@ func TestIgnoreRules_PrefixesWithExceptions(t *testing.T) {
 	assert.Contains(t, actual, "redis_instance_info")
 }
 
+func TestIgnoreRules_MetricTypesWithExceptions(t *testing.T) {
+	t.Parallel()
+
+	entity := scrapeString(t, prometheusInput)
+	filter(&entity, []IgnoreRule{
+		{
+			MetricTypes: []string{"gauge"}, Except: []string{"redis_instance_info"},
+		},
+	})
+
+	actual := map[string]interface{}{}
+	for _, metric := range entity.Metrics {
+		switch metric.name {
+		case "redis_instantaneous_input_kbps":
+			require.Fail(t, "redis_instantaneous_input_kbps must have been filtered")
+		case "redis_exporter_build_info":
+			require.Fail(t, "redis_exporter_build_info must have been filtered")
+		case "redis_exporter_scrapes_total":
+			actual[metric.name] = 1
+		case "redis_instance_info":
+			actual[metric.name] = 1
+		default:
+			require.Fail(t, "unexpected metric", "%#v", metric)
+		}
+	}
+
+	assert.Len(t, actual, 2)
+	assert.Contains(t, actual, "redis_exporter_scrapes_total")
+	assert.Contains(t, actual, "redis_instance_info")
+}
+
 func TestIgnoreRules_IgnoreAllExceptExceptions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
allow metric filtering by metric type
Ex.
```
transformations:
  - description: "General processing rules"
    ignore_metrics:
      - metric_types:
        - "histogram"
```

The use case is the ability to ignore histograms which generate a large number of (unused) metrics.
```
# HELP argocd_redis_request_duration Redis requests duration.
# TYPE argocd_redis_request_duration histogram
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.01"} 2.791635e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.05"} 3.347797e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.1"} 3.582787e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.25"} 3.609236e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="0.5"} 3.609581e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="1"} 3.609594e+06
argocd_redis_request_duration_bucket{hostname="argocd-application-controller-1",initiator="argocd-application-controller",le="+Inf"} 3.609602e+06
argocd_redis_request_duration_sum{hostname="argocd-application-controller-1",initiator="argocd-application-controller"} 41456.31533212083
argocd_redis_request_duration_count{hostname="argocd-application-controller-1",initiator="argocd-application-controller"} 3.609602e+06
```

In the above case since `# TYPE` is `histogram` the above metrics will be filtered out.
`Except` lists can be used for histograms which should be kept.

Signed-off-by: smcavallo <smcavallo@hotmail.com>