### PR TITLE
fix(infraSDKEmitter): Add tags as entity metadata

### DIFF
--- a/internal/integration/infra_sdk_emitter_test.go
+++ b/internal/integration/infra_sdk_emitter_test.go
@@ -381,27 +381,27 @@ redis_foo_test{hostname="localhost",env="dev",uniquelabel="test"} 3
 	}
 
 	em := e.EntityDef.Metadata
-	assert.Contains(t, em["tags.version"], "v1.10.0")
-	assert.Contains(t, em["tags.env"], "dev")
-	assert.Contains(t, em["tags.uniquelabel"], "test")
+	assert.Equal(t, "v1.10.0", em["version"])
+	assert.Equal(t, "dev", em["env"])
+	assert.Equal(t, "test", em["uniquelabel"])
 	assert.Contains(t, e.Common, "targetName")
 
 	e, ok = result.findEntity("REDIS_FOO:" + metrics.Target.Name)
 	assert.True(t, ok)
 	assert.Len(t, e.Metrics, 1)
 	em = e.EntityDef.Metadata
-	_, ok = em["tags.version"]
+	_, ok = em["version"]
 	assert.False(t, ok)
-	assert.Contains(t, em["tags.env"], "dev")
-	assert.Contains(t, em["tags.uniquelabel"], "test")
+	assert.Equal(t, "dev", em["env"])
+	assert.Equal(t, "test", em["uniquelabel"])
 
 	e, ok = result.findEntity("MULTI:" + metrics.Target.Name)
 	assert.True(t, ok)
 	assert.Len(t, e.Metrics, 2)
 	em = e.EntityDef.Metadata
-	assert.Contains(t, em["tags.env"], "dev")
-	assert.Contains(t, em["tags.foo"], "foo")
-	assert.Contains(t, em["tags.bar"], "bar")
+	assert.Equal(t, "dev", em["env"])
+	assert.Equal(t, "foo", em["foo"])
+	assert.Equal(t, "bar", em["bar"])
 
 	e, ok = result.findEntity("")
 	assert.True(t, ok)

--- a/internal/synthesis/synthesis.go
+++ b/internal/synthesis/synthesis.go
@@ -64,7 +64,7 @@ type EntityRule struct {
 	Identifier string      `mapstructure:"identifier"` // Name of the attribute that will be used to uniquely identify the synthesized entity.
 	Name       string      `mapstructure:"name"`       // Name of the attribute that will be used to name the synthesized entity.
 	Conditions []Condition `mapstructure:"conditions"` // List of rules used to determining if a metric belongs to this entity.
-	Tags       Tags        `mapstructure:"tags"`       // List of attributes that will be added to the entity as tags.
+	Tags       Tags        `mapstructure:"tags"`       // List of attributes that will be added to the entity as metadata.
 	tagRules   []tagRule   // List of all tags better structured to facilitate synthesis process.
 }
 
@@ -88,7 +88,7 @@ func (c Condition) match(attribute string) bool {
 	return strings.HasPrefix(attribute, c.Prefix)
 }
 
-// Tags stores a collection of attributes that will be added to the entity as tags as the keys of a map.
+// Tags stores a collection of attributes that will be added to the entity metadata as the keys of a map.
 // The values of the map contains optional rules that applies to the tag when synthetising, like renaming.
 type Tags map[string]map[string]interface{}
 
@@ -138,10 +138,11 @@ func (s Synthesizer) GetEntityMetadata(metricName string, attributes labels.Set)
 
 	md := sdk_metadata.New(entityName, rule.EntityType, entityDisplayName)
 
-	// Adds attributes as entity tag, sdk adds the prefix "tags." to the key.
+	// Adds attributes matching with definition tags as entity metadata.
+	// In Entity Definitions the term 'tag' is equivalent to the entity metadata in the infra sdk.
 	for _, t := range rule.tagRules {
 		if tagVal, ok := attributes[t.sourceAttribute]; ok {
-			md.AddTag(t.entityTagName, tagVal)
+			md.AddMetadata(t.entityTagName, tagVal)
 		}
 	}
 

--- a/internal/synthesis/synthesis_test.go
+++ b/internal/synthesis/synthesis_test.go
@@ -138,8 +138,8 @@ var redisEntityMetadata = sdk_metadata.Metadata{
 	DisplayName: "localhost:9999",
 	EntityType:  "REDIS",
 	Metadata: sdk_metadata.Map{
-		"tags.foo":           "bar",
-		"tags.preferredName": "renamedTagValue",
+		"foo":           "bar",
+		"preferredName": "renamedTagValue",
 	},
 }
 
@@ -148,7 +148,7 @@ var redisSecondEntityMetadata = sdk_metadata.Metadata{
 	DisplayName: "localhost:9999",
 	EntityType:  "REDIS_SECOND",
 	Metadata: sdk_metadata.Map{
-		"tags.foo": "bar",
+		"foo": "bar",
 	},
 }
 
@@ -164,7 +164,7 @@ var fooEntityMetadataMultiRule = sdk_metadata.Metadata{
 	DisplayName: "NiceName",
 	EntityType:  "FOO",
 	Metadata: sdk_metadata.Map{
-		"tags.commonAttribute": "commonAttributeValue",
+		"commonAttribute": "commonAttributeValue",
 	},
 }
 
@@ -333,8 +333,8 @@ func Test_synthesis_GetEntityMetadata(t *testing.T) {
 				DisplayName: "NiceName",
 				EntityType:  "FOO",
 				Metadata: sdk_metadata.Map{
-					"tags.commonAttribute": "commonAttributeValue",
-					"tags.tag1":            "Foo",
+					"commonAttribute": "commonAttributeValue",
+					"tag1":            "Foo",
 				},
 			}, true},
 		},


### PR DESCRIPTION
The agent distinguishes two kind of tags:
* tags that come in the telemetry and that aren’t changeable by the user - it calls it `metadata`. And this are the same that are defined in the [entity synthesis definitions](https://github.com/newrelic/entity-definitions/blob/main/definitions/infra-powerdns_authoritative/definition.yml#L12) as `tags`.

* tags that are defined by the user, either as [custom attributes](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings#custom-attributes) in the agent or as [labels](https://docs.newrelic.com/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/#labels) in the integration config. Those are handled by the Agent. 

We were adding the attributes as entity tags instead of metadata what caused the attributes names to be prefixed with `tags.` and making the backend synthesis to fail.