### PR TITLE
Add Basic auth functionality

### DIFF
--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -45,6 +45,7 @@ type Config struct {
 	AutoDecorate                      bool                         `mapstructure:"auto_decorate" default:"false"`
 	CaFile                            string                       `mapstructure:"ca_file"`
 	BearerTokenFile                   string                       `mapstructure:"bearer_token_file"`
+	BasicAuthFile                     string                       `mapstructure:"basic_auth_file"`
 	InsecureSkipVerify                bool                         `mapstructure:"insecure_skip_verify" default:"false"`
 	ProcessingRules                   []integration.ProcessingRule `mapstructure:"transformations"`
 	DecorateFile                      bool
@@ -171,7 +172,7 @@ func RunWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 		scrapeDuration,
 		selfRetriever,
 		retrievers,
-		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
+		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.BasicAuthFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
 		integration.RuleProcessor(processingRules, queueLength),
 		emitters)
 
@@ -212,7 +213,7 @@ func RunOnceWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 	// Fetch duration is hardcoded to 1 since the target is scraped only once
 	integration.ExecuteOnce(
 		retrievers,
-		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
+		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.BasicAuthFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
 		integration.RuleProcessor(cfg.ProcessingRules, queueLength),
 		emitters)
 

--- a/internal/integration/fetcher.go
+++ b/internal/integration/fetcher.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -97,7 +98,7 @@ type bearerAuthFileRoundTripper struct {
 
 func (rt *bearerAuthFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("Authorization")) == 0 {
-		b, err := ioutil.ReadFile(rt.bearerFile)
+		b, err := os.ReadFile(rt.bearerFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read bearer token file %s: %s", rt.bearerFile, err)
 		}

--- a/internal/integration/fetcher_test.go
+++ b/internal/integration/fetcher_test.go
@@ -32,7 +32,7 @@ func TestFetcher(t *testing.T) {
 	t.Parallel()
 
 	// Given a fetcher
-	fetcher := NewFetcher(fetchDuration, fetchTimeout, workerThreads, "", "", true, queueLength)
+	fetcher := NewFetcher(fetchDuration, fetchTimeout, workerThreads, "", "", "", true, queueLength)
 	var invokedURL string
 	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string) (names prometheus.MetricFamiliesByName, e error) {
 		invokedURL = url
@@ -69,7 +69,7 @@ func TestFetcher_Error(t *testing.T) {
 	t.Parallel()
 
 	// Given a fetcher
-	fetcher := NewFetcher(time.Millisecond, fetchTimeout, workerThreads, "", "", true, queueLength)
+	fetcher := NewFetcher(time.Millisecond, fetchTimeout, workerThreads, "", "", "", true, queueLength)
 
 	// That fails retrieving data from one of the metrics endpoint
 	invokedURLs := make([]string, 0)
@@ -123,7 +123,7 @@ func TestFetcher_ConcurrencyLimit(t *testing.T) {
 	reportedParallel := make(chan int32, queueLength)
 
 	// Given a Fetcher
-	fetcher := NewFetcher(time.Millisecond, fetchTimeout, workerThreads, "", "", true, queueLength)
+	fetcher := NewFetcher(time.Millisecond, fetchTimeout, workerThreads, "", "", "", true, queueLength)
 
 	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string) (names prometheus.MetricFamiliesByName, e error) {
 		defer atomic.AddInt32(&parallelTasks, -1)

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -42,7 +42,7 @@ func scrapeString(t *testing.T, inputMetrics string) TargetMetrics {
 	target, err := server.GetTargets()
 	require.NoError(t, err)
 
-	metricsCh := NewFetcher(time.Millisecond, 1*time.Second, workerThreads, "", "", true, queueLength).Fetch(target)
+	metricsCh := NewFetcher(time.Millisecond, 1*time.Second, workerThreads, "", "", "", true, queueLength).Fetch(target)
 
 	var pair TargetMetrics
 	select {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -57,7 +57,7 @@ func do(b *testing.B, retrievers []endpoints.TargetRetriever) {
 	b.ReportAllocs()
 	process(
 		retrievers,
-		NewFetcher(30*time.Second, 5000000000, 4, "", "", false, queueLength),
+		NewFetcher(30*time.Second, 5000000000, 4, "", "", "", false, queueLength),
 		RuleProcessor([]ProcessingRule{}, queueLength),
 		[]Emitter{&nilEmit{}},
 	)
@@ -112,7 +112,7 @@ func BenchmarkIntegrationInfraSDKEmitter(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ExecuteOnce(
 			retrievers,
-			NewFetcher(30*time.Second, 5000000000, 4, "", "", false, queueLength),
+			NewFetcher(30*time.Second, 5000000000, 4, "", "", "", false, queueLength),
 			RuleProcessor([]ProcessingRule{}, queueLength),
 			emitters)
 	}


### PR DESCRIPTION
This PR adds Basic Auth functionality to the client.

Rationale:
We use New Relic at work to collect metrics. However, we depend on third-party endpoints secured by basic authentication. Currently, NRI Prometheus does not provide the ability to specify a username and password.

Implementation details:
This PR adds a `basic_auth_file` configuration setting and `basicAuthRoundTripper`, which allow specifying a file that would be read on each request similarly to `bearerAuthFileRoundTripper`. The format of the credentials file is `<username>:<password>`. 