### PR TITLE
Add prometheus accept header

### DIFF
--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -36,6 +36,9 @@ func ResetTargetSize() {
 	targetSize.Reset()
 }
 
+// acceptHeader from Prometheus server https://github.com/prometheus/prometheus/blob/v2.33.1/scrape/scrape.go#L751
+const acceptHeader = `application/openmetrics-text;version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
+
 // Get scrapes the given URL and decodes the retrieved payload.
 func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 	mfs := MetricFamiliesByName{}
@@ -43,7 +46,9 @@ func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
 	if err != nil {
 		return mfs, err
 	}
-	req.Header.Set("Content-Type", "application/json")
+
+	req.Header.Add("Accept", acceptHeader)
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return mfs, err

--- a/internal/pkg/prometheus/prometheus_test.go
+++ b/internal/pkg/prometheus/prometheus_test.go
@@ -5,6 +5,7 @@ package prometheus_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,38 +13,24 @@ import (
 	"github.com/newrelic/nri-prometheus/internal/pkg/prometheus"
 )
 
-var result = `
-# HELP go_goroutines Number of goroutines that currently exist.
-# TYPE go_goroutines gauge
-go_goroutines 8
-# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
-# TYPE go_memstats_heap_idle_bytes gauge
-go_memstats_heap_idle_bytes 2.301952e+06
-# HELP go_gc_duration_seconds A summary of the GC invocation durations.
-# TYPE go_gc_duration_seconds summary
-go_gc_duration_seconds{quantile="0"} 7.5235e-05
-go_gc_duration_seconds{quantile="0.25"} 7.5235e-05
-go_gc_duration_seconds{quantile="0.5"} 0.000200349
-go_gc_duration_seconds{quantile="0.75"} 0.000200349
-go_gc_duration_seconds{quantile="1"} 0.000200349
-go_gc_duration_seconds_sum 0.000275584
-go_gc_duration_seconds_count 2
-# HELP http_requests_total Total number of HTTP requests made.
-# TYPE http_requests_total counter
-http_requests_total{code="200",handler="prometheus",method="get"} 2
-`
-
 func TestGet(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(result))
+		accept := r.Header.Get("Accept")
+		if !strings.Contains(accept, "application/openmetrics-text;") {
+			t.Errorf("Expected Accept header to prefer application/openmetrics-text, got %q", accept)
+		}
+
+		_, _ = w.Write([]byte("metric_a 1\nmetric_b 2\n"))
 	}))
 	defer ts.Close()
-	expected := []string{"go_goroutines", "go_memstats_heap_idle_bytes", "go_gc_duration_seconds", "http_requests_total"}
+
+	expected := []string{"metric_a", "metric_b"}
 	mfs, err := prometheus.Get(http.DefaultClient, ts.URL)
 	actual := []string{}
 	for k := range mfs {
 		actual = append(actual, k)
 	}
+
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expected, actual)
 }

--- a/internal/pkg/prometheus/prometheus_test.go
+++ b/internal/pkg/prometheus/prometheus_test.go
@@ -16,7 +16,7 @@ import (
 func TestGet(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
-		if !strings.Contains(accept, "application/openmetrics-text;") {
+		if !strings.Contains(accept, "application/openmetrics-text") {
 			t.Errorf("Expected Accept header to prefer application/openmetrics-text, got %q", accept)
 		}
 


### PR DESCRIPTION
Adds the `Accept` header with the same content as the Prometheus Server.

Removes the "application/json" content-type form the header as well since only prometheus text metrics can be parsed by this Getter 

fixes #252 