### PR TITLE
endpoints: add UseBearer flag and set it to true for nodes

### DIFF
--- a/internal/pkg/endpoints/endpoints.go
+++ b/internal/pkg/endpoints/endpoints.go
@@ -33,6 +33,9 @@ type Target struct {
 	URL       url.URL
 	metadata  labels.Set
 	TLSConfig TLSConfig
+	// UseBearer tells nri-prometheus whether it should send the Kubernetes Service Account token as a Bearer token in
+	// the HTTP request.
+	UseBearer bool
 }
 
 // Metadata returns the Target's metadata, if the current metadata is nil,

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -134,14 +134,16 @@ func nodeTargets(n *corev1.Node) ([]Target, error) {
 
 	return []Target{
 		{
-			Name:   n.Name,
-			URL:    nodeURL,
-			Object: object,
+			Name:      n.Name,
+			URL:       nodeURL,
+			Object:    object,
+			UseBearer: true,
 		},
 		{
-			Name:   "cadvisor_" + n.Name,
-			URL:    cadvisorURL,
-			Object: object,
+			Name:      "cadvisor_" + n.Name,
+			URL:       cadvisorURL,
+			Object:    object,
+			UseBearer: true,
 		},
 	}, nil
 }


### PR DESCRIPTION
Prior to this PR, `nri-prometheus` was sending the Kubernetes Service Account Token to endpoints that probably wouldn't need them. This PR introduces a flag in the `Target` struct, `UseBearer`, which is set to `true` for nodes only. Fetcher reacts to this flag by using a specific HTTP client that adds the token as an `Authorization` header.