### PR TITLE
endpoints/kubernetes: parse query args from prometheus.io/path

### DIFF
--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -2184,6 +2184,117 @@ func TestPodTargetsPathLabel(t *testing.T) {
 	)
 }
 
+func TestPodTargetsPathAnnotationCorrectQuery(t *testing.T) {
+	t.Parallel()
+
+	assert.ElementsMatch(
+		t,
+		podTargets(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-pod",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					"prometheus.io/path": "/metrics?format=prometheus",
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "node-a",
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http-app",
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				PodIP: "10.0.0.1",
+			},
+		}),
+		[]Target{
+			{
+				Name: "my-pod",
+				Object: Object{
+					Name: "my-pod",
+					Kind: "pod",
+					Labels: labels.Set{
+						"podName":        "my-pod",
+						"namespaceName":  "test-ns",
+						"deploymentName": "",
+						"nodeName":       "node-a",
+					},
+				},
+				URL: url.URL{
+					Scheme:   "http",
+					Host:     "10.0.0.1:80",
+					Path:     "/metrics",
+					RawQuery: "format=prometheus",
+				},
+			},
+		},
+	)
+}
+
+func TestPodTargetsPathAnnotationIncorrectQuery(t *testing.T) {
+	t.Parallel()
+
+	assert.ElementsMatch(
+		t,
+		podTargets(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-pod",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					"prometheus.io/path": "/metrics?format=prometheus?something",
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "node-a",
+				Containers: []corev1.Container{
+					{
+						Name: "app",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http-app",
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				PodIP: "10.0.0.1",
+			},
+		}),
+		[]Target{
+			{
+				Name: "my-pod",
+				Object: Object{
+					Name: "my-pod",
+					Kind: "pod",
+					Labels: labels.Set{
+						"podName":        "my-pod",
+						"namespaceName":  "test-ns",
+						"deploymentName": "",
+						"nodeName":       "node-a",
+					},
+				},
+				URL: url.URL{
+					Scheme: "http",
+					Host:   "10.0.0.1:80",
+					// This is fine, url.URL will escape this to /metrics%3Fformat%3Dprometheus%3Fsomething%0A
+					// upon making the request.
+					Path: "/metrics?format=prometheus?something",
+				},
+			},
+		},
+	)
+}
+
 func TestServiceTargetsPathAnnotationsOverrideLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -2249,7 +2249,7 @@ func TestPodTargetsPathAnnotationIncorrectQuery(t *testing.T) {
 				Name:      "my-pod",
 				Namespace: "test-ns",
 				Annotations: map[string]string{
-					"prometheus.io/path": "/metrics?format=prometheus?something",
+					"prometheus.io/path": "/metrics?for\nmat=promet\r\n",
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -2270,28 +2270,7 @@ func TestPodTargetsPathAnnotationIncorrectQuery(t *testing.T) {
 				PodIP: "10.0.0.1",
 			},
 		}),
-		[]Target{
-			{
-				Name: "my-pod",
-				Object: Object{
-					Name: "my-pod",
-					Kind: "pod",
-					Labels: labels.Set{
-						"podName":        "my-pod",
-						"namespaceName":  "test-ns",
-						"deploymentName": "",
-						"nodeName":       "node-a",
-					},
-				},
-				URL: url.URL{
-					Scheme: "http",
-					Host:   "10.0.0.1:80",
-					// This is fine, url.URL will escape this to /metrics%3Fformat%3Dprometheus%3Fsomething%0A
-					// upon making the request.
-					Path: "/metrics?format=prometheus?something",
-				},
-			},
-		},
+		[]Target{},
 	)
 }
 


### PR DESCRIPTION
As prometheus server abuses label concatenation using regexes, the `prometheus.io/path` annotation can be abused to include query paramenters such as `prometheus.io/path: /metrics?format=foo`, and this will be handled fine by it.

While this behavior is likely accidental, it has been set as standard and some edge cases rely upon it.

This PR allows `nri-prometheus` to support this use case, by pre-parsing the `prometheus.io/path` annotation into `path` and `query` before building the `url.URL` object.