### PR TITLE
fix(query): query params not included if port specified

### DIFF
--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -346,9 +346,10 @@ func serviceTargets(s *corev1.Service) []Target {
 
 	if port != "" {
 		u := url.URL{
-			Scheme: scheme,
-			Host:   net.JoinHostPort(fmt.Sprintf("%s.%s.svc", s.Name, s.Namespace), port),
-			Path:   path,
+			Scheme:   scheme,
+			Host:     net.JoinHostPort(fmt.Sprintf("%s.%s.svc", s.Name, s.Namespace), port),
+			Path:     path,
+			RawQuery: query,
 		}
 		return []Target{serviceTarget(s, u)}
 	}

--- a/internal/pkg/endpoints/kubernetes.go
+++ b/internal/pkg/endpoints/kubernetes.go
@@ -427,9 +427,10 @@ func podTargets(p *corev1.Pod) []Target {
 
 	if port != "" {
 		u := url.URL{
-			Scheme: scheme,
-			Host:   net.JoinHostPort(p.Status.PodIP, port),
-			Path:   path,
+			Scheme:   scheme,
+			Host:     net.JoinHostPort(p.Status.PodIP, port),
+			Path:     path,
+			RawQuery: query,
 		}
 		return []Target{podTarget(p, u)}
 	}

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -2194,7 +2194,8 @@ func TestPodTargetsPathAnnotationCorrectQuery(t *testing.T) {
 				Name:      "my-pod",
 				Namespace: "test-ns",
 				Annotations: map[string]string{
-					"prometheus.io/path": "/metrics?format=prometheus",
+					"prometheus.io/path": "/stats?format=prometheus&text_readouts",
+					"prometheus.io/port": "9901",
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -2230,9 +2231,9 @@ func TestPodTargetsPathAnnotationCorrectQuery(t *testing.T) {
 				},
 				URL: url.URL{
 					Scheme:   "http",
-					Host:     "10.0.0.1:80",
-					Path:     "/metrics",
-					RawQuery: "format=prometheus",
+					Host:     "10.0.0.1:9901",
+					Path:     "/stats",
+					RawQuery: "format=prometheus&text_readouts",
 				},
 			},
 		},


### PR DESCRIPTION
Query params were not included whenever a port was specified