### PR TITLE
fix(acceptHeader): rollback to text/plain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.16.2
+## Fix
+- AcceptHeader was including `application/openmetrics-text` that was not fully supported by the nri-prometheus parser
+
+## 2.16.1
+## Fix
+- Query params were not included if port was specified by @paologallinaharbur in #301
+
+## 2.16.0
+## Changed
+ - Query parameters, such as `?format=prometheus`, can now be specified in the `prometheus.io/path` label/annotation
+
+## 2.15.0
+## Changed
+ - Added `UseBearer` flag and set it to true for nodes by @roobre in #264
+ - chore(deps): bump github.com/prometheus/common from 0.32.1 to 0.33.0 by @dependabot in #271
+ - chore(deps): bump golangci/golangci-lint-action from 2 to 3.1.0 by @dependabot in #261
+
 ## 2.14.0
 ## Changed
 - Bump SDK version

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -94,6 +94,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("require_scrape_enabled_label_for_nodes", true)
 	viper.SetDefault("scrape_timeout", 5*time.Second)
 	viper.SetDefault("scrape_duration", "30s")
+	viper.SetDefault("scrape_accept_header", "text/plain;version=0.0.4")
 	viper.SetDefault("emitter_harvest_period", fmt.Sprint(integration.BoundedHarvesterDefaultHarvestPeriod))
 	viper.SetDefault("min_emitter_harvest_period", fmt.Sprint(integration.BoundedHarvesterDefaultMinReportInterval))
 	viper.SetDefault("max_stored_metrics", fmt.Sprint(integration.BoundedHarvesterDefaultMetricsCap))
@@ -105,7 +106,6 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("scrape_endpoints", false)
 	viper.SetDefault("percentiles", []float64{50.0, 95.0, 99.0})
 	viper.SetDefault("worker_threads", 4)
-	viper.SetDefault("accept_header", "text/plain;version=0.0.4")
 }
 
 // bindViperEnv automatically binds the variables in given configuration struct to environment variables.

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -105,6 +105,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("scrape_endpoints", false)
 	viper.SetDefault("percentiles", []float64{50.0, 95.0, 99.0})
 	viper.SetDefault("worker_threads", 4)
+	viper.SetDefault("accept_header", "text/plain;version=0.0.4")
 }
 
 // bindViperEnv automatically binds the variables in given configuration struct to environment variables.

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -94,6 +94,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("require_scrape_enabled_label_for_nodes", true)
 	viper.SetDefault("scrape_timeout", 5*time.Second)
 	viper.SetDefault("scrape_duration", "30s")
+	// Note that this default is taken directly from the Prometheus server acceptHeader prior to the open-metrics support. https://github.com/prometheus/prometheus/commit/9c03e11c2cf2ad6c638567471faa5c0f6c11ba3d
 	viper.SetDefault("scrape_accept_header", "text/plain;version=0.0.4;q=1,*/*;q=0.1")
 	viper.SetDefault("emitter_harvest_period", fmt.Sprint(integration.BoundedHarvesterDefaultHarvestPeriod))
 	viper.SetDefault("min_emitter_harvest_period", fmt.Sprint(integration.BoundedHarvesterDefaultMinReportInterval))

--- a/cmd/nri-prometheus/config.go
+++ b/cmd/nri-prometheus/config.go
@@ -94,7 +94,7 @@ func setViperDefaults(viper *viper.Viper) {
 	viper.SetDefault("require_scrape_enabled_label_for_nodes", true)
 	viper.SetDefault("scrape_timeout", 5*time.Second)
 	viper.SetDefault("scrape_duration", "30s")
-	viper.SetDefault("scrape_accept_header", "text/plain;version=0.0.4")
+	viper.SetDefault("scrape_accept_header", "text/plain;version=0.0.4;q=1,*/*;q=0.1")
 	viper.SetDefault("emitter_harvest_period", fmt.Sprint(integration.BoundedHarvesterDefaultHarvestPeriod))
 	viper.SetDefault("min_emitter_harvest_period", fmt.Sprint(integration.BoundedHarvesterDefaultMinReportInterval))
 	viper.SetDefault("max_stored_metrics", fmt.Sprint(integration.BoundedHarvesterDefaultMetricsCap))

--- a/cmd/nri-prometheus/config_test.go
+++ b/cmd/nri-prometheus/config_test.go
@@ -45,6 +45,7 @@ func TestLoadConfig(t *testing.T) {
 		ScrapeTimeout:                     5 * time.Second,
 		ScrapeServices:                    true,
 		ScrapeDuration:                    "5s",
+		ScrapeAcceptHeader:                "text/plain;version=0.0.4",
 		EmitterHarvestPeriod:              "1s",
 		MinEmitterHarvestPeriod:           "200ms",
 		MaxStoredMetrics:                  10000,

--- a/cmd/nri-prometheus/config_test.go
+++ b/cmd/nri-prometheus/config_test.go
@@ -45,7 +45,7 @@ func TestLoadConfig(t *testing.T) {
 		ScrapeTimeout:                     5 * time.Second,
 		ScrapeServices:                    true,
 		ScrapeDuration:                    "5s",
-		ScrapeAcceptHeader:                "text/plain;version=0.0.4",
+		ScrapeAcceptHeader:                "text/plain;version=0.0.4;q=1,*/*;q=0.1",
 		EmitterHarvestPeriod:              "1s",
 		MinEmitterHarvestPeriod:           "200ms",
 		MaxStoredMetrics:                  10000,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/common v0.34.0
+	github.com/prometheus/common v0.35.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -423,6 +423,8 @@ github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.34.0 h1:RBmGO9d/FVjqHT0yUGQwBJhkwKV+wPCn7KGpvfab0uE=
 github.com/prometheus/common v0.34.0/go.mod h1:gB3sOl7P0TvJabZpLY5uQMpUqRCPPCyRLCZYc7JZTNE=
+github.com/prometheus/common v0.35.0 h1:Eyr+Pw2VymWejHqCugNaQXkAi6KayVNxaHeu6khmFBE=
+github.com/prometheus/common v0.35.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=

--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -37,6 +37,7 @@ type Config struct {
 	ScrapeServices                    bool                         `mapstructure:"scrape_services"`
 	ScrapeEndpoints                   bool                         `mapstructure:"scrape_endpoints"`
 	ScrapeDuration                    string                       `mapstructure:"scrape_duration"`
+	ScrapeAcceptHeader                string                       `mapstructure:"accept_header"`
 	EmitterHarvestPeriod              string                       `mapstructure:"emitter_harvest_period"`
 	MinEmitterHarvestPeriod           string                       `mapstructure:"min_emitter_harvest_period"`
 	MaxStoredMetrics                  int                          `mapstructure:"max_stored_metrics"`
@@ -171,7 +172,7 @@ func RunWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 		scrapeDuration,
 		selfRetriever,
 		retrievers,
-		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
+		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.ScrapeAcceptHeader, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
 		integration.RuleProcessor(processingRules, queueLength),
 		emitters)
 
@@ -212,7 +213,7 @@ func RunOnceWithEmitters(cfg *Config, emitters []integration.Emitter) error {
 	// Fetch duration is hardcoded to 1 since the target is scraped only once
 	integration.ExecuteOnce(
 		retrievers,
-		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
+		integration.NewFetcher(scrapeDuration, cfg.ScrapeTimeout, cfg.ScrapeAcceptHeader, cfg.WorkerThreads, cfg.BearerTokenFile, cfg.CaFile, cfg.InsecureSkipVerify, queueLength),
 		integration.RuleProcessor(cfg.ProcessingRules, queueLength),
 		emitters)
 

--- a/internal/cmd/scraper/scraper.go
+++ b/internal/cmd/scraper/scraper.go
@@ -37,7 +37,7 @@ type Config struct {
 	ScrapeServices                    bool                         `mapstructure:"scrape_services"`
 	ScrapeEndpoints                   bool                         `mapstructure:"scrape_endpoints"`
 	ScrapeDuration                    string                       `mapstructure:"scrape_duration"`
-	ScrapeAcceptHeader                string                       `mapstructure:"accept_header"`
+	ScrapeAcceptHeader                string                       `mapstructure:"scrape_accept_header"`
 	EmitterHarvestPeriod              string                       `mapstructure:"emitter_harvest_period"`
 	MinEmitterHarvestPeriod           string                       `mapstructure:"min_emitter_harvest_period"`
 	MaxStoredMetrics                  int                          `mapstructure:"max_stored_metrics"`

--- a/internal/integration/fetcher.go
+++ b/internal/integration/fetcher.go
@@ -136,13 +136,13 @@ func NewFetcher(fetchDuration time.Duration, fetchTimeout time.Duration, acceptH
 	return &prometheusFetcher{
 		workerThreads: workerThreads,
 		queueLength:   queueLength,
-		httpClient:    client,
-		bearerClient:  bearerTokenClient,
 		duration:      fetchDuration,
 		fetchTimeout:  fetchTimeout,
+		acceptHeader:  acceptHeader,
+		httpClient:    client,
+		bearerClient:  bearerTokenClient,
 		getMetrics:    prometheus.Get,
 		log:           logrus.WithField("component", "Fetcher"),
-		acceptHeader:  acceptHeader,
 	}
 }
 
@@ -151,12 +151,12 @@ type prometheusFetcher struct {
 	queueLength   int
 	duration      time.Duration
 	fetchTimeout  time.Duration
+	acceptHeader  string
 	httpClient    prometheus.HTTPDoer
 	bearerClient  prometheus.HTTPDoer
 	// Provides IoC for better testability. Its usual value is 'prometheus.Get'.
-	getMetrics   func(httpClient prometheus.HTTPDoer, url string, acceptHeader string) (prometheus.MetricFamiliesByName, error)
-	log          *logrus.Entry
-	acceptHeader string
+	getMetrics func(httpClient prometheus.HTTPDoer, url string, acceptHeader string) (prometheus.MetricFamiliesByName, error)
+	log        *logrus.Entry
 }
 
 // Fetch implementation runs the connections to many targets in parallel, limited by the maxTargetConnections constant,

--- a/internal/integration/fetcher_test.go
+++ b/internal/integration/fetcher_test.go
@@ -32,9 +32,9 @@ func TestFetcher(t *testing.T) {
 	t.Parallel()
 
 	// Given a fetcher
-	fetcher := NewFetcher(fetchDuration, fetchTimeout, workerThreads, "", "", true, queueLength)
+	fetcher := NewFetcher(fetchDuration, fetchTimeout, "", workerThreads, "", "", true, queueLength)
 	var invokedURL string
-	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string) (names prometheus.MetricFamiliesByName, e error) {
+	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string, _ string) (names prometheus.MetricFamiliesByName, e error) {
 		invokedURL = url
 		return prometheus.MetricFamiliesByName{
 			"some-name": dto.MetricFamily{},
@@ -69,11 +69,11 @@ func TestFetcher_Error(t *testing.T) {
 	t.Parallel()
 
 	// Given a fetcher
-	fetcher := NewFetcher(time.Millisecond, fetchTimeout, workerThreads, "", "", true, queueLength)
+	fetcher := NewFetcher(time.Millisecond, fetchTimeout, "", workerThreads, "", "", true, queueLength)
 
 	// That fails retrieving data from one of the metrics endpoint
 	invokedURLs := make([]string, 0)
-	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string) (names prometheus.MetricFamiliesByName, e error) {
+	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string, _ string) (names prometheus.MetricFamiliesByName, e error) {
 		if strings.Contains(url, "fail") {
 			return nil, errors.New("catapun")
 		}
@@ -123,9 +123,9 @@ func TestFetcher_ConcurrencyLimit(t *testing.T) {
 	reportedParallel := make(chan int32, queueLength)
 
 	// Given a Fetcher
-	fetcher := NewFetcher(time.Millisecond, fetchTimeout, workerThreads, "", "", true, queueLength)
+	fetcher := NewFetcher(time.Millisecond, fetchTimeout, "", workerThreads, "", "", true, queueLength)
 
-	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string) (names prometheus.MetricFamiliesByName, e error) {
+	fetcher.(*prometheusFetcher).getMetrics = func(client prometheus.HTTPDoer, url string, _ string) (names prometheus.MetricFamiliesByName, e error) {
 		defer atomic.AddInt32(&parallelTasks, -1)
 		atomic.AddInt32(&parallelTasks, 1)
 		reportedParallel <- atomic.LoadInt32(&parallelTasks)

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -42,7 +42,7 @@ func scrapeString(t *testing.T, inputMetrics string) TargetMetrics {
 	target, err := server.GetTargets()
 	require.NoError(t, err)
 
-	metricsCh := NewFetcher(time.Millisecond, 1*time.Second, workerThreads, "", "", true, queueLength).Fetch(target)
+	metricsCh := NewFetcher(time.Millisecond, 1*time.Second, "", workerThreads, "", "", true, queueLength).Fetch(target)
 
 	var pair TargetMetrics
 	select {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -56,7 +56,7 @@ func do(b *testing.B, retrievers []endpoints.TargetRetriever) {
 	b.ReportAllocs()
 	process(
 		retrievers,
-		NewFetcher(30*time.Second, 5000000000, 4, "", "", false, queueLength),
+		NewFetcher(30*time.Second, 5000000000, "", 4, "", "", false, queueLength),
 		RuleProcessor([]ProcessingRule{}, queueLength),
 		[]Emitter{&nilEmit{}},
 	)
@@ -90,7 +90,7 @@ func BenchmarkIntegrationInfraSDKEmitter(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ExecuteOnce(
 			retrievers,
-			NewFetcher(30*time.Second, 5000000000, 4, "", "", false, queueLength),
+			NewFetcher(30*time.Second, 5000000000, "", 4, "", "", false, queueLength),
 			RuleProcessor([]ProcessingRule{}, queueLength),
 			emitters)
 	}

--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -36,11 +36,8 @@ func ResetTargetSize() {
 	targetSize.Reset()
 }
 
-// acceptHeader from Prometheus server https://github.com/prometheus/prometheus/blob/v2.33.1/scrape/scrape.go#L751
-const acceptHeader = `application/openmetrics-text;version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
-
 // Get scrapes the given URL and decodes the retrieved payload.
-func Get(client HTTPDoer, url string) (MetricFamiliesByName, error) {
+func Get(client HTTPDoer, url string, acceptHeader string) (MetricFamiliesByName, error) {
 	mfs := MetricFamiliesByName{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/internal/pkg/prometheus/prometheus_test.go
+++ b/internal/pkg/prometheus/prometheus_test.go
@@ -5,7 +5,6 @@ package prometheus_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,10 +12,12 @@ import (
 	"github.com/newrelic/nri-prometheus/internal/pkg/prometheus"
 )
 
-func TestGet(t *testing.T) {
+const testHeader = "application/openmetrics-text"
+
+func TestGetHeader(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
-		if !strings.Contains(accept, "application/openmetrics-text") {
+		if accept != testHeader {
 			t.Errorf("Expected Accept header to prefer application/openmetrics-text, got %q", accept)
 		}
 
@@ -25,7 +26,7 @@ func TestGet(t *testing.T) {
 	defer ts.Close()
 
 	expected := []string{"metric_a", "metric_b"}
-	mfs, err := prometheus.Get(http.DefaultClient, ts.URL)
+	mfs, err := prometheus.Get(http.DefaultClient, ts.URL, testHeader)
 	actual := []string{}
 	for k := range mfs {
 		actual = append(actual, k)

--- a/internal/pkg/prometheus/prometheus_test.go
+++ b/internal/pkg/prometheus/prometheus_test.go
@@ -18,7 +18,7 @@ func TestGetHeader(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		if accept != testHeader {
-			t.Errorf("Expected Accept header to prefer application/openmetrics-text, got %q", accept)
+			t.Errorf("Expected Accept header %s, got %q", testHeader, accept)
 		}
 
 		_, _ = w.Write([]byte("metric_a 1\nmetric_b 2\n"))


### PR DESCRIPTION
The purpose of the PR is to remove from the accept header the format we actually do not support such as `openmetrics` and `*/*`. At the same time 

Related to https://github.com/newrelic/nri-prometheus/issues/252. In order to support a specific use-case we added as acceptHeader the very same value the prometheus server had. However, the prometheus server has two different parsers one for `plain/text` and the other one for `application/openmetrics-text`.

We currently leverage `expfmt.FmtText` to formatdata. `github.com/prometheus/common/expfmt` also supports `application/openmetrics-text` but merely up to 0.0.1

Fix https://github.com/newrelic/nri-prometheus/issues/313 
Fix https://github.com/newrelic/nri-prometheus/issues/315

---

For example configuring:
```
    scrape_accept_header: "application/openmetrics-text;version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1"
```

having the fake openmetric exporter (by @gsanchezgavier 💟 ) running it fails:
```
time="2022-07-07T12:53:38Z" level=warning msg="fetching Prometheus metrics: http://172.17.0.9:8000/metrics (test-resources-openmetrics-858864575d-9fssr)" component=Fetcher error="text format parsing error in line 70: unknown metric type \"info\""
time="2022-07-07T12:53:38Z" level=warning msg="error while scraping target" component=Fetcher error="text format parsing error in line 70: unknown metric type \"info\""

```

with the default one it works