### PR TITLE
feat(useBearer): expose the config for static targets

### DIFF
--- a/cmd/nri-prometheus/config_test.go
+++ b/cmd/nri-prometheus/config_test.go
@@ -54,6 +54,7 @@ func TestLoadConfig(t *testing.T) {
 				Description: "AAA",
 				URLs:        []string{"localhost:9121"},
 				TLSConfig:   endpoints.TLSConfig{},
+				UseBearer:   true,
 			},
 		},
 		InsecureSkipVerify: true,

--- a/cmd/nri-prometheus/testdata/config-with-legacy-entity-definitions.yaml
+++ b/cmd/nri-prometheus/testdata/config-with-legacy-entity-definitions.yaml
@@ -20,6 +20,7 @@ entity_definitions: [
 targets:
   - description: "AAA"
     urls: ["localhost:9121"]
+    use_bearer: true
 verbose: true
 scrape_duration: "5s"
 insecure_skip_verify: true

--- a/internal/cmd/scraper/scraper_test.go
+++ b/internal/cmd/scraper/scraper_test.go
@@ -92,14 +92,16 @@ func TestConfigParseWithCustomType(t *testing.T) {
 	assert.Equal(t, licenseKey, string(cfg.LicenseKey))
 }
 
-func TestRunIntegrationOnce(t *testing.T) {
+func TestRunIntegrationOnceNoTokenAttached(t *testing.T) {
 	dat, err := ioutil.ReadFile("./testData/testData.prometheus")
 	require.NoError(t, err)
 	counter := 0
+	headers := http.Header{}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		_, _ = w.Write(dat)
+		headers = r.Header
 		counter++
 	}))
 	defer srv.Close()
@@ -118,6 +120,7 @@ func TestRunIntegrationOnce(t *testing.T) {
 	err = Run(c)
 	require.NoError(t, err)
 	require.Equal(t, 2, counter, "the scraper should have hit the mock exactly twice")
+	require.Equal(t, "", headers.Get("Authorization"), "the scraper should not add any authorization token")
 }
 
 func TestScrapingAnsweringWithError(t *testing.T) {

--- a/internal/pkg/endpoints/endpoints.go
+++ b/internal/pkg/endpoints/endpoints.go
@@ -84,6 +84,7 @@ func endpointToTarget(tc TargetConfig) ([]Target, error) {
 		if err != nil {
 			return nil, err
 		}
+		t.UseBearer = tc.UseBearer
 		targets = append(targets, t)
 	}
 	return targets, nil

--- a/internal/pkg/endpoints/fixed.go
+++ b/internal/pkg/endpoints/fixed.go
@@ -14,6 +14,7 @@ type TargetConfig struct {
 	Description string
 	URLs        []string  `mapstructure:"urls"`
 	TLSConfig   TLSConfig `mapstructure:"tls_config"`
+	UseBearer   bool      `mapstructure:"use_bearer"`
 }
 
 // TLSConfig is used to store all the configuration required to use Mutual TLS authentication.

--- a/internal/pkg/endpoints/fixed.go
+++ b/internal/pkg/endpoints/fixed.go
@@ -14,7 +14,9 @@ type TargetConfig struct {
 	Description string
 	URLs        []string  `mapstructure:"urls"`
 	TLSConfig   TLSConfig `mapstructure:"tls_config"`
-	UseBearer   bool      `mapstructure:"use_bearer"`
+	// UseBearer tells nri-prometheus whether it should send the Kubernetes Service Account token as a Bearer token in
+	// the HTTP request.
+	UseBearer bool `mapstructure:"use_bearer"`
 }
 
 // TLSConfig is used to store all the configuration required to use Mutual TLS authentication.


### PR DESCRIPTION
Attaching the token to all request would be a security issue. 

Therefore the decision was taken to attach it merely for static targets whenever the user was explicitly asking for it.
