### PR TITLE
chore(chart): bump to new version of the integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.16.3
+## Changed
+- Several dependencies updated
+- The `use_bearer` config is now exposed the config for static targets by @paologallinaharbur in https://github.com/newrelic/nri-prometheus/pull/327
+
 ## 2.16.2
 ## Fix
 - AcceptHeader was including `application/openmetrics-text` that was not fully supported by the nri-prometheus parser

--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -7,8 +7,8 @@ sources:
   - https://github.com/newrelic/nri-prometheus
   - https://github.com/newrelic/nri-prometheus/tree/master/charts/nri-prometheus
 
-version: 2.1.8
-appVersion: 2.16.2
+version: 2.1.9
+appVersion: 2.16.3
 
 dependencies:
   - name: common-library

--- a/charts/nri-prometheus/README.md
+++ b/charts/nri-prometheus/README.md
@@ -1,6 +1,6 @@
 # nri-prometheus
 
-![Version: 2.1.8](https://img.shields.io/badge/Version-2.1.8-informational?style=flat-square) ![AppVersion: 2.16.2](https://img.shields.io/badge/AppVersion-2.16.2-informational?style=flat-square)
+![Version: 2.1.8](https://img.shields.io/badge/Version-2.1.8-informational?style=flat-square) ![AppVersion: 2.16.3](https://img.shields.io/badge/AppVersion-2.16.3-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Prometheus OpenMetrics integration
 

--- a/charts/nri-prometheus/README.md
+++ b/charts/nri-prometheus/README.md
@@ -1,7 +1,5 @@
 # nri-prometheus
 
-![Version: 2.1.8](https://img.shields.io/badge/Version-2.1.8-informational?style=flat-square) ![AppVersion: 2.16.3](https://img.shields.io/badge/AppVersion-2.16.3-informational?style=flat-square)
-
 A Helm chart to deploy the New Relic Prometheus OpenMetrics integration
 
 **Homepage:** <https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations/>

--- a/charts/nri-prometheus/README.md.gotmpl
+++ b/charts/nri-prometheus/README.md.gotmpl
@@ -1,8 +1,6 @@
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.badgesSection" . }}
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}

--- a/charts/nri-prometheus/values.yaml
+++ b/charts/nri-prometheus/values.yaml
@@ -138,6 +138,8 @@ config:
   # targets:
   #   - description: Secure etcd example
   #     urls: ["https://192.168.3.1:2379", "https://192.168.3.2:2379", "https://192.168.3.3:2379"]
+  #     If true the Kubernetes Service Account token will be included as a Bearer token in the HTTP request.
+  #     use_bearer: false
   #     tls_config:
   #       ca_file_path: "/etc/etcd/etcd-client-ca.crt"
   #       cert_file_path: "/etc/etcd/etcd-client.crt"


### PR DESCRIPTION
Bumping the image to [v2.16.3](https://github.com/newrelic/nri-prometheus/releases/tag/v2.16.3) exposing the `use_bearer` option.

Several dependencies were also updated