### PR TITLE
Fix helm chart url

### DIFF
--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/newrelic/nri-prometheus
   - https://github.com/newrelic/nri-prometheus/tree/master/charts/nri-prometheus
 
-version: 2.1.9
+version: 2.1.10
 appVersion: 2.16.3
 
 dependencies:

--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/inst
 icon: https://newrelic.com/themes/custom/curio/assets/mediakit/new_relic_logo_vertical.svg
 sources:
   - https://github.com/newrelic/nri-prometheus
-  - https://github.com/newrelic/nri-prometheus/tree/master/charts/nri-prometheus
+  - https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus
 
 version: 2.1.10
 appVersion: 2.16.3

--- a/charts/nri-prometheus/README.md
+++ b/charts/nri-prometheus/README.md
@@ -17,7 +17,7 @@ helm upgrade --install nri-prometheus/nri-prometheus -f your-custom-values.yaml
 ## Source Code
 
 * <https://github.com/newrelic/nri-prometheus>
-* <https://github.com/newrelic/nri-prometheus/tree/master/charts/nri-prometheus>
+* <https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus>
 
 ## Scraping services and endpoints
 


### PR DESCRIPTION
Relates to https://github.com/newrelic/helm-charts/issues/845.

Fix url to point to the proper branch.