### PR TITLE
NEWRELIC-3719 fix(filters): multiple rules bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.16.6
+## Changed
+- Several dependencies updated
+## Fix
+- https://github.com/newrelic/nri-prometheus/issues/344 The Bug was caused by a wrong implementation of the filtering feature.
+In particular, it was not possible having `lowDataMode=true` to filter out everything including just some metrics.
+
 ## 2.16.5
 ## Changed
 - Several dependencies updated

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
-	k8s.io/api v0.25.1
-	k8s.io/apimachinery v0.25.1
-	k8s.io/client-go v0.25.1
+	k8s.io/api v0.25.2
+	k8s.io/apimachinery v0.25.2
+	k8s.io/client-go v0.25.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,7 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f h1:qqqIhBDFUBrbMezIyJkKWIpf+E5CdObleGMjW1s19Hg=
 github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
@@ -702,12 +703,12 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/api v0.25.1 h1:yL7du50yc93k17nH/Xe9jujAYrcDkI/i5DL1jPz4E3M=
-k8s.io/api v0.25.1/go.mod h1:hh4itDvrWSJsmeUc28rIFNri8MatNAAxJjKcQmhX6TU=
-k8s.io/apimachinery v0.25.1 h1:t0XrnmCEHVgJlR2arwO8Awp9ylluDic706WePaYCBTI=
-k8s.io/apimachinery v0.25.1/go.mod h1:hqqA1X0bsgsxI6dXsJ4HnNTBOmJNxyPp8dw3u2fSHwA=
-k8s.io/client-go v0.25.1 h1:uFj4AJKtE1/ckcSKz8IhgAuZTdRXZDKev8g387ndD58=
-k8s.io/client-go v0.25.1/go.mod h1:rdFWTLV/uj2C74zGbQzOsmXPUtMAjSf7ajil4iJUNKo=
+k8s.io/api v0.25.2 h1:v6G8RyFcwf0HR5jQGIAYlvtRNrxMJQG1xJzaSeVnIS8=
+k8s.io/api v0.25.2/go.mod h1:qP1Rn4sCVFwx/xIhe+we2cwBLTXNcheRyYXwajonhy0=
+k8s.io/apimachinery v0.25.2 h1:WbxfAjCx+AeN8Ilp9joWnyJ6xu9OMeS/fsfjK/5zaQs=
+k8s.io/apimachinery v0.25.2/go.mod h1:hqqA1X0bsgsxI6dXsJ4HnNTBOmJNxyPp8dw3u2fSHwA=
+k8s.io/client-go v0.25.2 h1:SUPp9p5CwM0yXGQrwYurw9LWz+YtMwhWd0GqOsSiefo=
+k8s.io/client-go v0.25.2/go.mod h1:i7cNU7N+yGQmJkewcRD2+Vuj4iz7b30kI8OcL3horQ4=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.70.1 h1:7aaoSdahviPmR+XkS7FyxlkkXs6tHISSG03RxleQAVQ=
 k8s.io/klog/v2 v2.70.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=

--- a/go.sum
+++ b/go.sum
@@ -308,7 +308,6 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f h1:qqqIhBDFUBrbMezIyJkKWIpf+E5CdObleGMjW1s19Hg=
 github.com/sirupsen/logrus v1.6.1-0.20200528085638-6699a89a232f/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/internal/integration/rules.go
+++ b/internal/integration/rules.go
@@ -209,17 +209,19 @@ func addAttributes(targetMetrics *TargetMetrics, rules []AddAttributesRule) {
 type ignoreRules []IgnoreRule
 
 func (rules ignoreRules) shouldIgnore(name string, metricType metricType) bool {
-	var prefixesLen, metricTypesLen, exceptRulesLen int
+	if rules.isMetricExcludedFromFilters(name) {
+		return false
+	}
+
 	for _, rule := range rules {
-		exceptRulesLen += len(rule.Except)
-		for _, prefix := range rule.Except {
-			if strings.HasPrefix(name, prefix) {
-				return false
-			}
+		// if metricTypesLen or prefixesLen are not defined and exceptRulesLen
+		// is not empty then all not excepted metric should be dropped
+		totalDroppingRules := len(rule.MetricTypes) + len(rule.Prefixes)
+		if totalDroppingRules == 0 && len(rule.Except) != 0 {
+			return true
 		}
 
 		// MetricTypes
-		metricTypesLen += len(rule.MetricTypes)
 		for _, rMetricType := range rule.MetricTypes {
 			if strings.EqualFold(rMetricType, string(metricType)) {
 				return true
@@ -227,7 +229,6 @@ func (rules ignoreRules) shouldIgnore(name string, metricType metricType) bool {
 		}
 
 		// Prefixes
-		prefixesLen += len(rule.Prefixes)
 		for _, prefix := range rule.Prefixes {
 			if strings.HasPrefix(name, prefix) {
 				return true
@@ -235,12 +236,20 @@ func (rules ignoreRules) shouldIgnore(name string, metricType metricType) bool {
 		}
 	}
 
-	if prefixesLen > 0 || metricTypesLen > 0 {
-		return false
+	return false
+}
+
+// When matching an except rule we do not drop the metric, no matter if a rule is dropping it after
+func (rules ignoreRules) isMetricExcludedFromFilters(name string) bool {
+	for _, rule := range rules {
+		for _, prefix := range rule.Except {
+			if strings.HasPrefix(name, prefix) {
+				return true
+			}
+		}
 	}
 
-	// only exceptions were provided and the current metric is not an exception
-	return exceptRulesLen > 0
+	return false
 }
 
 // filter removes the metrics whose name matches the prefixes in the given ignore rules

--- a/internal/integration/rules.go
+++ b/internal/integration/rules.go
@@ -209,13 +209,14 @@ func addAttributes(targetMetrics *TargetMetrics, rules []AddAttributesRule) {
 type ignoreRules []IgnoreRule
 
 func (rules ignoreRules) shouldIgnore(name string, metricType metricType) bool {
-	if rules.isMetricExcludedFromFilters(name) {
+	// If the user specified ,in any set of rules, an except rule that is matching the metric name, we should keep the metric
+	if rules.isMetricExcepted(name) {
 		return false
 	}
 
 	for _, rule := range rules {
 		// if metricTypesLen or prefixesLen are not defined and exceptRulesLen
-		// is not empty then all not excepted metric should be dropped
+		// is not empty then all not previously excepted metric should be dropped
 		totalDroppingRules := len(rule.MetricTypes) + len(rule.Prefixes)
 		if totalDroppingRules == 0 && len(rule.Except) != 0 {
 			return true
@@ -240,7 +241,7 @@ func (rules ignoreRules) shouldIgnore(name string, metricType metricType) bool {
 }
 
 // When matching an except rule we do not drop the metric, no matter if a rule is dropping it after
-func (rules ignoreRules) isMetricExcludedFromFilters(name string) bool {
+func (rules ignoreRules) isMetricExcepted(name string) bool {
 	for _, rule := range rules {
 		for _, prefix := range rule.Except {
 			if strings.HasPrefix(name, prefix) {

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -437,7 +437,6 @@ func TestEmptyIgnoreRules(t *testing.T) {
 	})
 
 	assert.Len(t, entity.Metrics, 6)
-
 }
 
 func TestIgnoreRules(t *testing.T) {

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -572,3 +572,44 @@ func TestIgnoreRules_IgnoreAllExceptExceptions(t *testing.T) {
 	assert.Contains(t, actual, "redis_exporter_build_info")
 	assert.Contains(t, actual, "redis_instance_info")
 }
+
+func TestIgnoreRules_MatchingExceptRulesTakesPriorityOverOtherRules(t *testing.T) {
+	t.Parallel()
+
+	entity := scrapeString(t, prometheusInput)
+	filter(&entity, []IgnoreRule{
+		{
+			Prefixes:    []string{"redis_instance"},
+			MetricTypes: []string{"counter"},
+		},
+		{
+			Except: []string{"redis_instance"},
+		},
+		{
+			Except: []string{"something_different"},
+		},
+		{
+			Prefixes:    []string{"redis_instance"},
+			MetricTypes: []string{"counter"},
+		},
+	})
+
+	actual := map[string]interface{}{}
+	for _, metric := range entity.Metrics {
+		switch metric.name {
+		case "redis_exporter_build_info":
+			require.Fail(t, "redis_exporter_build_info must have been filtered")
+		case "redis_instantaneous_input_kbps":
+			require.Fail(t, "redis_instantaneous_input_kbps must have been filtered")
+		case "redis_exporter_scrapes_total":
+			require.Fail(t, "redis_exporter_scrapes_total must have been filtered")
+		case "redis_instance_info":
+			actual[metric.name] = 1
+		default:
+			require.Fail(t, "unexpected metric", "%#v", metric)
+		}
+	}
+
+	assert.Len(t, actual, 1)
+	assert.Contains(t, actual, "redis_instance_info")
+}

--- a/internal/integration/rules_test.go
+++ b/internal/integration/rules_test.go
@@ -428,6 +428,18 @@ func TestAddAttributesRules(t *testing.T) {
 	}
 }
 
+func TestEmptyIgnoreRules(t *testing.T) {
+	t.Parallel()
+
+	entity := scrapeString(t, prometheusInput)
+	filter(&entity, []IgnoreRule{
+		{},
+	})
+
+	assert.Len(t, entity.Metrics, 6)
+
+}
+
 func TestIgnoreRules(t *testing.T) {
 	t.Parallel()
 
@@ -535,6 +547,9 @@ func TestIgnoreRules_IgnoreAllExceptExceptions(t *testing.T) {
 		},
 		{
 			Except: []string{"redis_instance"},
+		},
+		{
+			Prefixes: []string{"not_matching"},
 		},
 	})
 


### PR DESCRIPTION
Fix https://github.com/newrelic/nri-prometheus/issues/344

The previous implementation was counting prefixes and metricTypes from all rules when applying the excludes.

With the old implementation the testcase TestIgnoreRules was starting to fail adding a prefix without any effect to a different rule.

The risk of solving this bug is breaking the config of users relying on a bug to collect metrics