### PR TITLE
chore: fix config example default values

### DIFF
--- a/configs/nri-prometheus-config.yml.sample
+++ b/configs/nri-prometheus-config.yml.sample
@@ -27,7 +27,7 @@ integrations:
       audit: false
 
       # The HTTP client timeout when fetching data from endpoints. Defaults to "5s" if it is not set.
-      # scrape_timeout: "30s"
+      # scrape_timeout: "5s"
 
       # Length in time to distribute the scraping from the endpoints. Default to "30s" if it is not set.
       scrape_duration: "5s"

--- a/configs/nri-prometheus-config.yml.sample
+++ b/configs/nri-prometheus-config.yml.sample
@@ -26,10 +26,10 @@ integrations:
       # It does not include verbose mode. This can lead to a high log volume, use with care.
       audit: false
 
-      # The HTTP client timeout when fetching data from endpoints. Defaults to 30s.
+      # The HTTP client timeout when fetching data from endpoints. Defaults to "5s" if it is not set.
       # scrape_timeout: "30s"
 
-      # Length in time to distribute the scraping from the endpoints.
+      # Length in time to distribute the scraping from the endpoints. Default to "30s" if it is not set.
       scrape_duration: "5s"
 
       # Number of worker threads used for scraping targets.


### PR DESCRIPTION
The default value for `scrape_timeout` in the config example comment is misleading because wasn't reflecting the [default value actually being used](https://github.com/newrelic/nri-prometheus/blob/chore/update-config-examples/cmd/nri-prometheus/config.go#L96).