### PR TITLE
chore(pomi): update appVersion

### DIFF
--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           minikube version: v1.30.1
           kubernetes version: v1.25.6
+          driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run load tests

--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -20,20 +20,6 @@ jobs:
         run: |
           sudo wget -O /usr/local/bin/skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
           sudo chmod +x /usr/local/bin/skaffold
-      # Load test uses skaffold to run `nri-prometheus` in the cluster. skaffold is not compatible with minikube when the
-      # clusters do not use docker as CRI giving this error:
-      #
-      # invalid skaffold config: getting minikube env: running [/home/runner/work/_temp/minikube docker-env --shell none -p minikube --user=skaffold]
-      #  - stdout: "false exit code 14\n"
-      #  - stderr: "X Exiting due to MK_USAGE: The docker-env command is only compatible with the \"docker\" runtime, but this cluster was configured to use the \"containerd\" runtime.\n"
-      #  - cause: exit status 14
-      #
-      # Se we are in a dependency cycle:
-      #  - Minikube with Kubernetes > 1.24 needs the CRI to NOT be docker
-      #  - Skaffold needs the CRI to be docker
-      #
-      # Here we test `nri-prometheus`, Kubernetes is just a tool we use for testing, so we should not care about the version 
-      # of Kubernetes and we should not upgrade it so the test keeps working.
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.7.2
         with:

--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: v1.15.1
-          kubernetes version: v1.19.4
+          minikube version: v1.30.1
+          kubernetes version: v1.25.6
           github token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run load tests

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -42,7 +42,7 @@ jobs:
           helm plugin install https://github.com/helm-unittest/helm-unittest
           for chart in $(ct --config .github/ct.yaml list-changed); do
             if [ -d "$chart/tests/" ]; then
-              helm unittest -3 $chart
+              helm unittest $chart
             else
               echo "No unit tests found for $chart"
             fi

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -52,6 +52,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         with:
           minikube version: v1.30.1
+          driver: docker
           kubernetes version: ${{ matrix.kubernetes-version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v4

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -51,7 +51,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.7.2
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.29.0
+          minikube version: v1.30.1
           kubernetes version: ${{ matrix.kubernetes-version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v4

--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -7,8 +7,8 @@ sources:
   - https://github.com/newrelic/nri-prometheus
   - https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus
 
-version: 2.1.16
-appVersion: 2.18.0
+version: 2.1.17
+appVersion: 2.18.4
 
 dependencies:
   - name: common-library

--- a/charts/nri-prometheus/tests/configmap_test.yaml
+++ b/charts/nri-prometheus/tests/configmap_test.yaml
@@ -9,7 +9,7 @@ tests:
       cluster: my-cluster-name
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["config.yaml"]
           value: |-
             cluster_name: my-cluster-name
             audit: false
@@ -28,7 +28,7 @@ tests:
       lowDataMode: true
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["config.yaml"]
           value: |-
             cluster_name: my-cluster-name
             audit: false
@@ -61,7 +61,7 @@ tests:
                 container_name: containerName
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["config.yaml"]
           value: |-
             cluster_name: my-cluster-name
             audit: false

--- a/charts/nri-prometheus/tests/deployment_test.yaml
+++ b/charts/nri-prometheus/tests/deployment_test.yaml
@@ -13,11 +13,11 @@ tests:
       cluster: test
     asserts:
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/instance]
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
           value: release
         template: templates/deployment.yaml
       - equal:
-          path: spec.template.metadata.labels.[app.kubernetes.io/name]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: nri-prometheus
         template: templates/deployment.yaml
       - equal:
@@ -26,7 +26,7 @@ tests:
             app.kubernetes.io/name: nri-prometheus
         template: templates/deployment.yaml
       - isNotEmpty:
-          path: spec.template.metadata.annotations.[checksum/config]
+          path: spec.template.metadata.annotations["checksum/config"]
         template: templates/deployment.yaml
 
   - it: adds METRIC_API_URL when nrStaging is true.

--- a/charts/nri-prometheus/tests/labels_test.yaml
+++ b/charts/nri-prometheus/tests/labels_test.yaml
@@ -18,15 +18,15 @@ tests:
       cluster: test
     asserts:
       - equal:
-          path: metadata.labels.[app.kubernetes.io/instance]
+          path: metadata.labels["app.kubernetes.io/instance"]
           value: release
       - equal:
-          path: metadata.labels.[app.kubernetes.io/managed-by]
+          path: metadata.labels["app.kubernetes.io/managed-by"]
           value: Helm
       - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: nri-prometheus
       - isNotEmpty:
-          path: metadata.labels.[app.kubernetes.io/version]
+          path: metadata.labels["app.kubernetes.io/version"]
       - isNotEmpty:
-          path: metadata.labels.[helm.sh/chart]
+          path: metadata.labels["helm.sh/chart"]


### PR DESCRIPTION
We were not updating the chart version due to https://github.com/renovatebot/renovate/issues/13968

We should understand if we want to move the version to the values.yaml or change the renovate config to support regexes