### PR TITLE
chore(golang): pin golang version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster
+FROM golang:1.20.6-bookworm
 
 ARG GH_VERSION='2.23.0'
 


### PR DESCRIPTION
We decided to pin golang version and [automerge them](https://github.com/newrelic/coreint-automation/commit/398ade41391d36da64320e123d832566d201601b)