### PR TITLE
Do not target services with port that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Enhancement
+- Skip prometheus services with non-existing port
+
 ## v2.19.0 - 2023-11-02
 
 ### 🚀 Enhancements

--- a/internal/pkg/endpoints/kubernetes_test.go
+++ b/internal/pkg/endpoints/kubernetes_test.go
@@ -356,6 +356,13 @@ func populateFakeEndpointsDataSinglePort(clientset *fake.Clientset) error {
 				"prometheus.io/port":   "1",
 			},
 		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port: 1,
+				},
+			},
+		},
 	}
 
 	_, err := clientset.CoreV1().Services("test-ns").Create(context.TODO(), s, metav1.CreateOptions{})
@@ -1637,6 +1644,36 @@ func TestServiceTargetsInvalidPortAnnotaion(t *testing.T) {
 				},
 			},
 		},
+	)
+}
+
+func TestServiceTargetsNonExistingPort(t *testing.T) {
+	t.Parallel()
+
+	assert.ElementsMatch(
+		t,
+		serviceTargets(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-service",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					"prometheus.io/port": "5000",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "http-app",
+						Port: 80,
+					},
+					{
+						Name: "http-app2",
+						Port: 8080,
+					},
+				},
+			},
+		}),
+		[]Target{},
 	)
 }
 


### PR DESCRIPTION
When `prometheus.io/port` annotation is set, no matter what, it just creates the target according the annotation value.

This potentially could make unnecessary calls to non-exposed port that end up with errors on every scrape tick.

```
... context deadline exceeded (Client.Timeout exceeded while awaiting headers) ...
```

This can be easily validated so this PR adds check for desired port and **throws a single error** if port does not exist.


_Note: It's user error, so correct solution is to get rid of annotation, however, annotation might be static in third party packages therefore unnecessary overrides are needed till it's get fixed. In each case, this cloud help to have cleaner logs when user error occurs._