### PR TITLE
Enhance Metric Filtering in nri-prometheus

### DIFF
--- a/internal/integration/rules.go
+++ b/internal/integration/rules.go
@@ -27,14 +27,21 @@ type RenameRule struct {
 	Attributes   map[string]interface{} `mapstructure:"attributes"`
 }
 
+type ExceptAttributeRule struct {
+	MetricPrefix   string `mapstructure:"metric_prefix"`
+	AttributeKey   string `mapstructure:"attribute_key"`
+	AttributeValue string `mapstructure:"attribute_value"`
+}
+
 // IgnoreRule skips for processing metrics that match any of the Prefixes or MetricTypes.
 // Metrics that match any of the Except are never skipped.
 // If Prefixes are empty and Except is not, then all metrics that do not
 // match Except will be skipped.
 type IgnoreRule struct {
-	Prefixes    []string `mapstructure:"prefixes"`
-	MetricTypes []string `mapstructure:"metric_types"`
-	Except      []string `mapstructure:"except"`
+	Prefixes         []string              `mapstructure:"prefixes"`
+	MetricTypes      []string              `mapstructure:"metric_types"`
+	Except           []string              `mapstructure:"except"`
+	ExceptAttributes []ExceptAttributeRule `mapstructure:"except_attributes"`
 }
 
 // CopyAttributesRule is a rule that copies the Attributes from the metric that
@@ -208,9 +215,9 @@ func addAttributes(targetMetrics *TargetMetrics, rules []AddAttributesRule) {
 
 type ignoreRules []IgnoreRule
 
-func (rules ignoreRules) shouldIgnore(name string, metricType metricType) bool {
-	// If the user specified ,in any set of rules, an except rule that is matching the metric name, we should keep the metric
-	if rules.isMetricExcepted(name) {
+func (rules ignoreRules) shouldIgnore(name string, metricType metricType, attributes labels.Set) bool {
+	// If the user specified in any set of rules, an except rule that is matching the metric name, we should keep the metric
+	if rules.isMetricExcepted(name) || rules.isAttributeExcepted(name, attributes) {
 		return false
 	}
 
@@ -253,6 +260,38 @@ func (rules ignoreRules) isMetricExcepted(name string) bool {
 	return false
 }
 
+// When matching an except rule we do not drop the metric, no matter if a rule is dropping it after
+func (rules ignoreRules) isAttributeExcepted(name string, attributes labels.Set) bool {
+	for _, rule := range rules {
+		for _, exceptItem := range rule.ExceptAttributes {
+			prefixMatched := false
+			attributeMatched := false
+
+			if strings.HasPrefix(name, exceptItem.MetricPrefix) {
+				prefixMatched = true
+			}
+
+			for attributeKey, attributeValue := range attributes {
+				if exceptItem.AttributeKey == "" && exceptItem.AttributeValue == "" {
+					attributeMatched = true
+					break
+				}
+
+				if exceptItem.AttributeKey == attributeKey && exceptItem.AttributeValue == attributeValue.(string) {
+					attributeMatched = true
+					break
+				}
+			}
+
+			if prefixMatched == true && attributeMatched == true {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // filter removes the metrics whose name matches the prefixes in the given ignore rules
 func filter(targetMetrics *TargetMetrics, rules ignoreRules) {
 	// Fast path, quickly exit if there are no rules defined.
@@ -262,7 +301,7 @@ func filter(targetMetrics *TargetMetrics, rules ignoreRules) {
 
 	copied := make([]Metric, 0, len(targetMetrics.Metrics))
 	for _, m := range targetMetrics.Metrics {
-		if !rules.shouldIgnore(m.name, m.metricType) {
+		if !rules.shouldIgnore(m.name, m.metricType, m.attributes) {
 			copied = append(copied, m)
 		}
 	}


### PR DESCRIPTION
# Overview
This pull request introduces an enhancement to the metric filtering functionality in the nri-prometheus project. Previously, users could only ignore metrics based on prefixes. With this update, I've added the capability to ignore metrics based on attributes.

# Changes Made
In the existing implementation, metric exclusion was limited to prefixes using the except option. Now, users can leverage the new except_attributes option to filter metrics based on specific attribute values. This provides more granular control over the metrics that are included in the processing pipeline.

# Usage Example
Before you can use only prefixes with `except` keyword:

```yaml
transformations:
  - description: "General processing rules"
    ignore_metrics:
      - except:
        - kube_hpa_
```

Now you can use also `except_attributes`:

```yaml
transformations:
  - description: "General processing rules"
    ignore_metrics:
      - except_attributes:
        - {metric_prefix: kube_hpa_, attribute_key: address, attribute_value: kube-host-1}
```

# How to Use
To ignore metrics with attributes, simply update your configuration file as shown in the example above. This change allows for more flexibility in managing and processing metrics based on specific attributes.

Testing
I have included comprehensive unit tests to ensure the proper functioning of the new feature. All existing tests have been updated to reflect these changes.

Additional Notes
I believe that this enhancement will provide users with greater control and flexibility in managing metrics within the nri-prometheus project. Your feedback on this feature is highly appreciated.

Thank you for your attention and consideration.