### PR TITLE
Feat/header xprometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Enhancement
+- Added XPrometheusHeader to allow exporters to give up complex computation when needed.
+
 ## v2.20.1 - 2024-01-03
 
 ### ⛓️ Dependencies
@@ -105,7 +108,7 @@ In particular, it was not possible having `lowDataMode=true` to filter out every
 
 ## 2.16.3
 ## Changed
-- Several dependencies updated 
+- Several dependencies updated
 - The `use_bearer` config is now exposed the config for static targets by @paologallinaharbur in https://github.com/newrelic/nri-prometheus/pull/327
 
 ## 2.16.2

--- a/configs/nri-prometheus-config.yml.sample
+++ b/configs/nri-prometheus-config.yml.sample
@@ -27,6 +27,7 @@ integrations:
       audit: false
 
       # The HTTP client timeout when fetching data from endpoints. Defaults to "5s" if it is not set.
+      # This timeout in seconds is passed as well as a X-Prometheus-Scrape-Timeout-Seconds header to the exporters
       # scrape_timeout: "5s"
 
       # Length in time to distribute the scraping from the endpoints. Default to "30s" if it is not set.

--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -36,15 +36,23 @@ func ResetTargetSize() {
 	targetSize.Reset()
 }
 
+const (
+	// XPrometheusScrapeTimeoutHeader included in all requests. It informs exporters about its timeout.
+	XPrometheusScrapeTimeoutHeader = "X-Prometheus-Scrape-Timeout-Seconds"
+	// AcceptHeader included in all requests
+	AcceptHeader = "Accept"
+)
+
 // Get scrapes the given URL and decodes the retrieved payload.
-func Get(client HTTPDoer, url string, acceptHeader string) (MetricFamiliesByName, error) {
+func Get(client HTTPDoer, url string, acceptHeader string, fetchTimeout string) (MetricFamiliesByName, error) {
 	mfs := MetricFamiliesByName{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return mfs, err
 	}
 
-	req.Header.Add("Accept", acceptHeader)
+	req.Header.Add(AcceptHeader, acceptHeader)
+	req.Header.Add(XPrometheusScrapeTimeoutHeader, fetchTimeout)
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Some exporters assume to receive this header in order to stop complex computations.
https://github.com/percona/mongodb_exporter/blob/6b436b67c9ee63745d20d9c059403185ad0b7aed/exporter/exporter.go#L273

Prometheus server is including it in all requests:
https://github.com/prometheus/prometheus/blob/ac10cd4d9966ae7a86c696cd7440ddce13f5c068/scrape/scrape.go#L712

