### PR TITLE
fix: default resources to empty

### DIFF
--- a/charts/nri-prometheus/Chart.yaml
+++ b/charts/nri-prometheus/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/newrelic/nri-prometheus
   - https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus
 
-version: 2.1.17
+version: 2.1.18
 appVersion: 2.18.4
 
 dependencies:

--- a/charts/nri-prometheus/templates/deployment.yaml
+++ b/charts/nri-prometheus/templates/deployment.yaml
@@ -71,10 +71,8 @@ spec:
             value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
           - name: "CA_FILE"
             value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-        {{- if .Values.resources }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        {{- end }}
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

Writes the default of `resources: {`} instead of omitting. The current behavior causes tools like argocd to show a diff.
This is because if the field does not exist kubernetes will set the default.
![image](https://github.com/newrelic/nri-prometheus/assets/14805373/eea680c1-7096-4735-97ca-b90e0877947b)

There is already a default in values.yaml and the default is `{}` so there is no need to wrap in a conditional.

New behavior is:
`helm template --values=values.yaml --set licenseKey=123 --set cluster=default .`
```
      containers:
      - name: nri-prometheus
        image: "newrelic/nri-prometheus:2.18.4"
        imagePullPolicy:
        args:
          - "--configfile=/etc/nri-prometheus/config.yaml"
        ports:
          - containerPort: 8080
        volumeMounts:
        - name: config-volume
          mountPath: /etc/nri-prometheus/
        env:
          - name: "LICENSE_KEY"
            valueFrom:
                secretKeyRef:
                  name: release-name-nri-prometheus-license
                  key: licenseKey
          - name: "BEARER_TOKEN_FILE"
            value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
          - name: "CA_FILE"
            value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
        resources:
          {}
      volumes:
        - name: config-volume
          configMap:
            name: release-name-nri-prometheus
```

