### PR TITLE
release now uses reusable workflow

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -10,19 +10,23 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
     with:
       original_repo_name: "newrelic/nri-prometheus"
       docker_image_name: "newrelic/nri-prometheus"
       integration_name: "prometheus"
 
-      generate_packages: true
-      # bucket_url: uses default
-
       run_nix_unit_tests: true
       run_windows_unit_tests: true
       
       release_command_sh: |
+        export GENERATE_PACKAGES=true
+        export S3_PATH=${S3_BASE_FOLDER}
+        if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+          export TAG_SUFFIX="-pre"
+        else
+          export TAG_SUFFIX=""
+        fi
         make release
         make ci/prerelease-fips
     

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
     with:
       original_repo_name: "newrelic/nri-prometheus"
       docker_platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -8,121 +8,29 @@ on:
     tags:
       - "v*"
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  INTEGRATION: "prometheus"
-  ORIGINAL_REPO_NAME: "newrelic/nri-prometheus"
-  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  TAG: ${{ github.event.release.tag_name }}
-  S3_PATH: s3://nr-downloads-main/infrastructure_agent
-  TAG_SUFFIX: "" # This suffix is used for pre-release only
-
 jobs:
-  test-nix:
-    name: Run unit tests on *Nix
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Unit tests
-        run: make ci/test
+  container-release:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    with:
+      original_repo_name: "newrelic/nri-prometheus"
+      docker_platforms: "linux/amd64,linux/arm64"
+      docker_image_name: "newrelic/nri-prometheus"
+      integration_name: "prometheus"
+      s_three_path: "s3://nr-downloads-main/infrastructure_agent"
+      go_version_file: "go.mod"
+      
+      run_nix_unit_tests: true
+      run_windows_unit_tests: true
+      run_integration_tests: false
+      
+      use_build_push_action: false  # Using custom release command
+      use_custom_release: true
 
-  test-windows:
-    name: Run unit tests on Windows
-    runs-on: windows-latest
-    env:
-      GOPATH: ${{ github.workspace }}
-    defaults:
-      run:
-        working-directory: src/github.com/${{env.ORIGINAL_REPO_NAME}}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: src/github.com/${{env.ORIGINAL_REPO_NAME}}
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: "src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
-      - name: Running unit tests
-        shell: pwsh
-        run: |
-          .\build\windows\unit_tests.ps1
-
-  integration-release:
-    name: Use goreleaser for releasing
-    runs-on: ubuntu-latest
-    needs: [test-nix, test-windows]
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: "go.mod"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
-      - name: Add pre-release tag
-        if: ${{ github.event.release.prerelease }}
-        run: |
-          echo "TAG_SUFFIX=-pre" >> $GITHUB_ENV
-      - name: do the release
-        # The release target is not being executed inside a container (ci/release) since the target
-        # compiles docker images (from goreleaser) and that cannot be done inside a container.
-        run: make release
-        env:
-          GENERATE_PACKAGES: true
-          PRERELEASE: ${{ github.event.release.prerelease }}
-      - name: release fips
-        # FIPS packages need to be built in the fips container
-        # TODO: It should be refactored when we change the way docker images are being built
-        run: make ci/prerelease-fips
-        env:
-          GENERATE_PACKAGES: true
-          PRERELEASE: ${{ github.event.release.prerelease }}
-
-      - if: ${{ github.event.release.prerelease }}
-        name: Update title for successful pre-release
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name  }} --title "${{ github.event.release.tag_name  }}"
-
-  notify-failure:
-    if: ${{ always() && failure() }}
-    needs: [test-nix, test-windows, integration-release]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify failure via Slack
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [release pipeline failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."
-
-  update-release-title-on-failure:
-    if: ${{ always() && failure() }}
-    needs: [test-nix, test-windows, integration-release]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - if: ${{ github.event.release.prerelease }}
-        name: Reflect failure in pre-release title
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name  }} --title "${{ github.event.release.tag_name }} (pre-release-failure)"
-      - if: ${{ ! github.event.release.prerelease }}
-        name: Reflect failure in release title
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name  }} --title "${{ github.event.release.tag_name }} (release-failure)"
+      release_command: |
+        make release
+        make ci/prerelease-fips
+    
+    secrets:
+      docker_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
+      docker_password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
+      bot_token: ${{ secrets.COREINT_BOT_TOKEN }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -13,12 +13,14 @@ jobs:
     uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
     with:
       original_repo_name: "newrelic/nri-prometheus"
-      docker_platforms: "linux/amd64,linux/arm64"
       docker_image_name: "newrelic/nri-prometheus"
       integration_name: "prometheus"
-      s_three_path: "s3://nr-downloads-main/infrastructure_agent"
+
+      docker_platforms: "linux/amd64,linux/arm64,linux/arm"
       go_version_file: "go.mod"
-      
+      generate_packages: true
+      bucket_url: "s3://nr-downloads-main/infrastructure_agent"
+
       run_nix_unit_tests: true
       run_windows_unit_tests: true
       

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-prometheus"
       docker_platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-prometheus"
       docker_image_name: "newrelic/nri-prometheus"

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -10,16 +10,14 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-prometheus"
       docker_image_name: "newrelic/nri-prometheus"
       integration_name: "prometheus"
 
-      docker_platforms: "linux/amd64,linux/arm64,linux/arm"
-      go_version_file: "go.mod"
       generate_packages: true
-      bucket_url: "s3://nr-downloads-main/infrastructure_agent"
+      # bucket_url: uses default
 
       run_nix_unit_tests: true
       run_windows_unit_tests: true

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
     with:
       original_repo_name: "newrelic/nri-prometheus"
       docker_platforms: "linux/amd64,linux/arm64"
@@ -21,12 +21,8 @@ jobs:
       
       run_nix_unit_tests: true
       run_windows_unit_tests: true
-      run_integration_tests: false
       
-      use_build_push_action: false  # Using custom release command
-      use_custom_release: true
-
-      release_command: |
+      release_command_sh: |
         make release
         make ci/prerelease-fips
     

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,11 +6,8 @@ on:
       - main
       - renovate/**
   pull_request:
-  schedule:
-    - cron: "0 3 * * *"
 
 jobs:
-  # Note: Snyk SaaS is already configured for this repository, which does not need a workflow to run
   trivy:
     name: Trivy security scan
     runs-on: ubuntu-latest
@@ -20,28 +17,10 @@ jobs:
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@master
-        if: ${{ ! github.event.schedule }} # Do not run inline checks when running periodically
+        if: contains(fromJSON('["push", "pull_request"]'), github.event_name)
         with:
           scan-type: fs
           ignore-unfixed: true
           exit-code: 1
           severity: 'HIGH,CRITICAL'
           skip-dirs: 'tools'
-
-      - name: Run Trivy vulnerability scanner sarif output
-        uses: aquasecurity/trivy-action@master
-        if: ${{ github.event.schedule }} # Generate sarif when running periodically
-        with:
-          scan-type: fs
-          ignore-unfixed: true
-          severity: 'HIGH,CRITICAL'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          skip-dirs: 'tools'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        if: ${{ github.event.schedule }} # Upload sarif when running periodically
-        with:
-          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Tested the reusable workflow for pre releases.
This PR depends on https://github.com/newrelic/coreint-automation/pull/103
Merge that and then point the job to the correct branch before merging