### PR TITLE
slack channel and token passed as secrets

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,6 +18,8 @@ jobs:
     secrets:
       docker_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
       docker_password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
+      slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
     with:
       docker_image: newrelic/nri-prometheus
       docker_tag: nightly

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -34,3 +34,5 @@ jobs:
       docker_username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
       docker_password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
       bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
+      slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}


### PR DESCRIPTION
Pass slack channel and and slack token as secrets to the reusable nightly and image release workflows.