### PR TITLE
goreleaser adding version to binaries

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -66,7 +66,6 @@ jobs:
           export GOOS=linux
           export GOARCH=amd64
           make ci/build
-
           # Find the highest versioned amd64 build directory
           # Sort numerically on the version suffix (e.g., _v1, _v2)
           latest_dir=$(ls -d ./dist/nri-prometheus-nix_linux_amd64* | sort -V | tail -n1)
@@ -74,7 +73,6 @@ jobs:
             echo "Error: No matching build directory found"
             exit 1
           fi
-
           sudo cp "${latest_dir}/nri-prometheus" ./bin/nri-prometheus
           DOCKER_BUILDKIT=1 docker build -t e2e/nri-prometheus:test  . -f Dockerfile.dev
           minikube image load e2e/nri-prometheus:test
@@ -101,6 +99,8 @@ jobs:
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           only-new-issues: true
+          skip-cache: true
+          version: v1.63
       - name: Check if CHANGELOG is valid
         uses: newrelic/release-toolkit/validate-markdown@v1
 

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -62,8 +62,20 @@ jobs:
       - name: Create image for chart testing
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          TAG=test GOOS=linux GOARCH=amd64 make ci/build
-          sudo cp ./dist/nri-prometheus-nix_linux_amd64_v1/nri-prometheus ./bin/nri-prometheus
+          export TAG=test
+          export GOOS=linux
+          export GOARCH=amd64
+          make ci/build
+
+          # Find the highest versioned amd64 build directory
+          # Sort numerically on the version suffix (e.g., _v1, _v2)
+          latest_dir=$(ls -d ./dist/nri-prometheus-nix_linux_amd64* | sort -V | tail -n1)
+          if [ -z "$latest_dir" ]; then
+            echo "Error: No matching build directory found"
+            exit 1
+          fi
+
+          sudo cp "${latest_dir}/nri-prometheus" ./bin/nri-prometheus
           DOCKER_BUILDKIT=1 docker build -t e2e/nri-prometheus:test  . -f Dockerfile.dev
           minikube image load e2e/nri-prometheus:test
       - name: Test install charts

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -63,7 +63,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           TAG=test GOOS=linux GOARCH=amd64 make ci/build
-          sudo cp ./dist/nri-prometheus-nix_linux_amd64/nri-prometheus ./bin/nri-prometheus
+          sudo cp ./dist/nri-prometheus-nix_linux_amd64_v1/nri-prometheus ./bin/nri-prometheus
           DOCKER_BUILDKIT=1 docker build -t e2e/nri-prometheus:test  . -f Dockerfile.dev
           minikube image load e2e/nri-prometheus:test
       - name: Test install charts

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -95,11 +95,10 @@ jobs:
         with:
           golangci-lint-config: golangci-lint-limited
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           only-new-issues: true
-          skip-cache: true
           version: v1.63
       - name: Check if CHANGELOG is valid
         uses: newrelic/release-toolkit/validate-markdown@v1


### PR DESCRIPTION
https://goreleaser.com/customization/builds/go/

```
# GOAMD64 to build when GOARCH is amd64.
    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
    #
    # Default: [ 'v1' ].
    goamd64:
      - v2
      - v3

    # GOARM64 to build when GOARCH is arm64.
    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
    #
    # Default: [ 'v8.0' ].
    # Since: v2.4.
    goarm64:
      - v9.0

    # GOMIPS and GOMIPS64 to build when GOARCH is mips, mips64, mipsle or mips64le.
    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
    #
    # Default: [ 'hardfloat' ].
    # Since: v2.4.
    gomips:
      - hardfloat
      - softfloat

    # GO386 to build when GOARCH is 386.
    # For more info refer to: https://pkg.go.dev/cmd/go#hdr-Environment_variables
    # and https://go.dev/wiki/MinimumRequirements#microarchitecture-support
    #
    # Default: [ 'sse2' ].
    # Since: v2.4.
    go386:
      - sse2
      - softfloat
```