### PR TITLE
security: add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -7,7 +7,7 @@ on:
 
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release_management:

--- a/.github/workflows/automated_release.yaml
+++ b/.github/workflows/automated_release.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 12 * * 3"
 
+
+permissions:
+  contents: read
+
 jobs:
   release_management:
     uses: newrelic/coreint-automation/.github/workflows/reusable_release_automation.yaml@v3

--- a/.github/workflows/load_test.yml
+++ b/.github/workflows/load_test.yml
@@ -4,6 +4,10 @@ on:
       - main
   pull_request:
 
+
+permissions:
+  contents: read
+
 name: Load Tests
 jobs:
   load_tests:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+
+permissions:
+  contents: read
+
 env:
   INTEGRATION: "prometheus"
   ORIGINAL_REPO_NAME: 'newrelic/nri-prometheus'

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -7,6 +7,10 @@ on:
       - renovate/**
   pull_request:
 
+
+permissions:
+  contents: read
+
 env:
   TAG: "v0.0.0" # needed for goreleaser windows builds
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -6,7 +6,7 @@ on:
 
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   #   Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+
+permissions:
+  contents: read
+
 jobs:
   #   Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo
   #   This job checks the remote file is up to date with the local one on release

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - "v*"
 
+
+permissions:
+  contents: read
+
 jobs:
   container-release:
     uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,10 @@ on:
       - renovate/**
   pull_request:
 
+
+permissions:
+  contents: read
+
 jobs:
   trivy:
     name: Trivy security scan


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all workflow files missing a permissions block
- Follows the principle of least privilege for GitHub Actions tokens
- Resolves CodeQL alert `actions/missing-workflow-permissions` ([NR-560157](https://new-relic.atlassian.net/browse/NR-560157))

## Test plan
- [ ] Verify CI workflows still pass with the new permissions block
- [ ] Confirm CodeQL alert is resolved after merge

[NR-560157]: https://new-relic.atlassian.net/browse/NR-560157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ