### PR TITLE
update go version to v1.25.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### security
+- upgrade go version to 1.25.10
+
 ## v2.29.0 - 2026-04-20
 
 ### 🛡️ Security notices

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-prometheus
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/newrelic/infra-integrations-sdk/v4 v4.2.1


### PR DESCRIPTION
## Summary

Addresses [NR-564347](https://new-relic.atlassian.net/browse/NR-564347) — Trivy/Grype flag 11 CVEs per OHAI component (6 HIGH, 5 MEDIUM) resolved by upgrading to **Go 1.25.10** or 1.26.3.

Bumps `go.mod` from 1.25.9 → 1.25.10 and adds a `### security` entry to the Unreleased CHANGELOG section. Mirrors the prior 1.25.8 → 1.25.9 bump (#558).

Note: the in-flight `deps-go-update-1.26` branch targets 1.26.2 (not the 1.26.3 the Jira requires) and is 2 weeks stale. This 1.25.10 bump is the simpler path; a follow-up to 1.26.3 can land separately if desired.

## Test plan

- [x] `make test` — all unit tests pass locally (Go 1.26.3 runtime)
- [ ] CI (push_pr) checks on push

[NR-564347]: https://new-relic.atlassian.net/browse/NR-564347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ